### PR TITLE
Initial implementation of shared examples

### DIFF
--- a/lib/dr_spec/core.rb
+++ b/lib/dr_spec/core.rb
@@ -1,3 +1,43 @@
+def shared_examples name, &block
+  examples_context = { description: name, subcontexts: [],
+                       tests: [],
+                       befores: [],
+                       afters:  [] }
+  previous_context = @current_context
+  @current_context = examples_context
+  block.call
+  @current_context = previous_context
+  @shared_examples ||= {}
+  @shared_examples[name] = examples_context
+end
+
+def include_examples name
+  examples = @shared_examples[name]
+  unless examples
+    raise KeyError.new("shared example not found: #{name}")
+  end
+  @current_context[:subcontexts].concat(examples[:subcontexts])
+  @current_context[:tests].concat(examples[:tests])
+  @current_context[:befores].concat(examples[:befores])
+  @current_context[:afters].concat(examples[:afters])
+end
+
+def it_behaves_like name
+  examples = @shared_examples[name]
+  unless examples
+    raise KeyError.new("shared example not found: #{name}")
+  end
+
+  subcontext = {
+    description: examples[:name],
+    subcontexts: examples[:subcontexts],
+    tests: examples[:tests],
+    befores: @current_context[:befores] + examples[:befores],
+    afters: @current_context[:afters] + examples[:afters],
+  }
+  @current_context[:subcontexts] << subcontext
+end
+
 def focus_spec name, metadata = {}, &block
   spec name, metadata.merge(focus: true), &block
 end

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -52,4 +52,5 @@ require 'lib/dr_spec/core/patch.rb'
 #
 require "spec/matchers_1_spec.rb"
 require "spec/matchers_2_spec.rb"
+require "spec/shared_examples_spec.rb"
 require "spec/main_spec.rb"

--- a/spec/shared_examples_spec.rb
+++ b/spec/shared_examples_spec.rb
@@ -1,0 +1,55 @@
+spec :shared_example do
+  shared_examples "a point" do
+    it "has an x" do
+      expect(object.x).not_to be_nil
+    end
+
+    it "has a y" do
+      expect(object.y).not_to be_nil
+    end
+  end
+
+  context "with an object" do
+    before do
+      def object
+        { x: 5, y: 6 }
+      end
+    end
+
+    it_behaves_like "a point"
+  end
+end
+
+spec :shared_example_from_separate_spec_block do
+  # Long term, these should be isolated by context, but we
+  # currently don't have a way to include them outside the
+  # same context, so they're currently global.
+  context "with an object" do
+    before do
+      def object
+        { x: 5, y: 6 }
+      end
+    end
+
+    it_behaves_like "a point"
+  end
+end
+
+spec :include_examples do
+  shared_examples "defines value to be 0" do
+    before do
+      def value
+        0
+      end
+    end
+  end
+
+  context "with the examples included" do
+    include_examples "defines value to be 0"
+
+    it "defines value" do
+      expect(respond_to?(:value)).to eq(true)
+      expect(value).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Currently it only implements `shared_examples`, `include_examples`, and `it_behaves_like`. Shared example groups are also currently not scoped to a context and can be included from other contexts; I took this approach because iiuc there's not a good way to e.g. define them in a module and include the module where you need them in dr_spec yet (which I think is an approach sometimes used in RSpec).

My implementation approach is to essentially create a parent-less context that gets stored in the `@shared_examples` hash. When including them, that context gets copied in as a subcontext (prepending parent befores/afters to its own) or has its tests/etc. added to the current context.

It's currently in the core.rb file since I hadn't initially pulled the commit that split that file up, but I can pull it into a separate file if you'd like.