### PR TITLE
Add Smaug support.

### DIFF
--- a/.smaugignore
+++ b/.smaugignore
@@ -1,0 +1,5 @@
+*
+!/lib/**/*
+!/LICENSE
+!/README.md
+!/Smaug.toml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     thor (1.2.2)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -7,13 +7,66 @@ It try to mimic rspec.
 
 🚧 **dr_spec is a work in progress! It works, but the interfaces may change.** 🚧
 
-# Install
+## Install
 
-1. copy `lib/dr_spec` folder into your dragon ruby projects
-2. create or copy the `spec` folder
-3. on your `app/main.rb` or `app/test.rb` file add `require "lib/dr_spec/dragon_specs.rb"` at the bottom of file
+### Manually
 
-# Basic example
+1. copy `lib/dr_spec` folder into your dragon ruby project.
+2. on your `app/main.rb` or `app/test.rb` file add `require "lib/dr_spec/dragon_specs.rb"` at the bottom of the file.
+
+That's it! Now you can write specs for your app using `dr_spec`.
+
+### Using `smaug`
+
+If you're using `smaug` to manage dependencies, you can install `dr_spec` by adding it to your `Smaug.toml`:
+
+```toml
+dr_spec = { repo = "https://github.com/levaleureux/dr_spec" }
+```
+
+Then simply run `smaug install` and add `require "smaug/dr_spec/lib/dr_spec/dragon_specs`
+to your `app/main.rb` or `app/test.rb` file.
+
+## Setup
+
+Setting up and running your specs is easy. After you followed the installation instruction above, you're ready to create
+your specs entrypoint file. This is normally `app/main.rb` or `app/test.rb`, but you can also have it in the `spec` folder if you prefer to keep it separate from your app code.
+
+```ruby
+# spec/main.rb
+require "lib/dr_spec/dragon_specs.rb" # or if you're using smaug: require 'smaug/dr_spec/lib/dr_spec/dragon_specs'
+
+spec "Setup specs" do
+  it "works" do
+    expect(true).to be_truthy
+  end
+end
+```
+
+## Running specs
+
+### With manual install
+
+If you have installed `dr_spec` manually into your dragonruby project, you should have the `dragonruby` executable in
+the same project folder. To run the specs, simply run:
+
+```bash
+./dragonruby . --test spec/main.rb`
+```
+
+Remember to replace `spec/main.rb` if you chose a different spec's entrypoint file.
+
+### With smaug
+
+If you are using smaug, you can also use it to run specs:
+
+```bash
+smaug run --test spec/main.rb
+```
+
+## Usage
+
+### Basic example
 
 To describe your `spec` or `it` block you can use a :symbole or a "string" with any case or spaces.
 
@@ -65,7 +118,7 @@ end
 
 ```
 
-# Structure
+### Structure
 
 1. spec
 2. context
@@ -75,14 +128,14 @@ end
 it like rspec. If you want to use this lib it's maybe because you already know
 rspec. If you want more doc please open an issue ;)
 
-# Matchers
+## Matchers
 
 **!🚧 ! NOTE check the implementation file as the doc is not 100% align with matchers
 names yet**
 
 dr_spec try to replicate some commonly used standard matchers in RSpec:
 
-## Equality
+### Equality
 
 `eq`: Verifies that two values are equal.
 <!--
@@ -94,40 +147,40 @@ dr_spec try to replicate some commonly used standard matchers in RSpec:
 another.
 1. be <, be <=: Verifies that a value is less (or less or equal) than another.
 
-## Boolean
+### Boolean
 
 1. be_truthy: Verifies that a value evaluates to true in a boolean context.
 1. be_falsey: Verifies that a value evaluates to false in a boolean context.
 1. `be_nil` Verifies that a value evaluates to nil.
 
-## Type
+### Type
 
 1. be_a(type) or be_an(type): Verifies that the object is an instance of the
 specified type.
 1. be_instance_of(type): Verifies that the object is an exact instance of the
 specified type.
 
-## Collection Content
+### Collection Content
 
 1. include(element): Verifies that an element is included in a collection.
 1. match_array(array): Verifies that the collection is equivalent to the specified
 array.
 
-## String
+### String
 
 1. start_with(string): Verifies that a string starts with the specified text.
 1. end_with(string): Verifies that a string ends with the specified text.
 1. include(string): Verifies that a string contains the specified text.
 
 
-# Outputs
+## Outputs
 
 There is on this project a will to make a very fast and readable output
 
 <img src="image.png" alt="some output" width="300">
 
 
-# Improve de doc
+## Improve de doc
 
 If you want to help on the doc of this project.
 you can use grip to preview your markdown.

--- a/Smaug.toml
+++ b/Smaug.toml
@@ -1,0 +1,23 @@
+[package]
+name = "dr_spec"
+authors = ["levaleureux"]
+version = "0.1.0"
+homepage = "https://github.com/levaleureux/dr_spec"
+keywords = ['dragonruby', 'rspec']
+
+# Optional:
+# documentation = "https://example.com"
+repository = "https://github.com/levaleureux/dr_spec"
+
+# Which files do you want to be automatically required from your package.
+requires = []
+
+[package.installs]
+# Example
+#
+# <from> = <to>
+# "lib/library.rb" = "app/lib/library.rb"
+
+[dragonruby]
+version = "5.9"
+edition = "standard"

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -28,30 +28,30 @@ def run_specs
   end
 end
 
-require "lib/dr_spec/core_matchers.rb"
+require_relative "core_matchers.rb"
 #
-require "lib/dr_spec/matchers/boolean_matchers.rb"
-require "lib/dr_spec/matchers/collection_matchers.rb"
-require "lib/dr_spec/matchers/matchers.rb"
-require "lib/dr_spec/matchers/numeric_comparison_matchers.rb"
-require "lib/dr_spec/matchers/string_matchers.rb"
-require "lib/dr_spec/matchers/type_matchers.rb"
-require "lib/dr_spec/core/shared_example.rb"
-require "lib/dr_spec/core/utils.rb"
-require "lib/dr_spec/core/blocks.rb"
-require "lib/dr_spec/core.rb"
-require "lib/dr_spec/tests_formater.rb"
+require_relative "matchers/boolean_matchers.rb"
+require_relative "matchers/collection_matchers.rb"
+require_relative "matchers/matchers.rb"
+require_relative "matchers/numeric_comparison_matchers.rb"
+require_relative "matchers/string_matchers.rb"
+require_relative "matchers/type_matchers.rb"
+require_relative "core/shared_example.rb"
+require_relative "core/utils.rb"
+require_relative "core/blocks.rb"
+require_relative "core.rb"
+require_relative "tests_formater.rb"
 
 # add requires for additional test files here
 
 # this must be required last
-require 'lib/dr_spec/core/patch.rb'
+require_relative "core/patch.rb"
 
 # require your spec here
 #
 # last spec must contain run_specs call
 #
-require "spec/matchers_1_spec.rb"
-require "spec/matchers_2_spec.rb"
-require "spec/shared_examples_spec.rb"
-require "spec/main_spec.rb"
+# require "spec/matchers_1_spec.rb"
+# require "spec/matchers_2_spec.rb"
+# require "spec/shared_examples_spec.rb"
+# require "spec/main_spec.rb"


### PR DESCRIPTION
This is achieved by using `require_relative` rather than `require`.
This removes the assumption that the library is installed in the `lib/dr_spec` folder.
Add alternative Smaug install instructions to README.