### PR TITLE
Automatically load all specs under `spec/**/*_spec` on macOS and Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ spec "Setup specs" do
 end
 ```
 
+### Organising specs
+
+You can organise specs into different files and put them in any folder structure that makes sense for your app.
+Just remember to require all spec files in your main spec entrypoint file (after requiring dr_spec).
+
+If you're on macOS or Linux, `dr_spec` will automatically require all files under `spec/**` that end with `_spec.rb`.
+
 ## Running specs
 
 ### With manual install

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -28,6 +28,22 @@ def run_specs
   end
 end
 
+def require_specs(current_dir = 'spec')
+  files = $gtk.exec("ls #{current_dir}").split("\n")
+  return unless files.is_a?(Array)
+
+  files.each do |file|
+    path, ext = file.split('.')
+    if ext
+      require "#{current_dir}/#{path}" if path.end_with?('_spec')
+    else
+      require_specs("#{current_dir}/#{path}")
+    end
+  end
+rescue
+  puts 'Could not auto-load specs. Currently only Linux and macOS are supported. Are you running on Windows?'
+end
+
 require_relative "core_matchers.rb"
 #
 require_relative "matchers/boolean_matchers.rb"
@@ -47,11 +63,4 @@ require_relative "tests_formater.rb"
 # this must be required last
 require_relative "core/patch.rb"
 
-# require your spec here
-#
-# last spec must contain run_specs call
-#
-# require "spec/matchers_1_spec.rb"
-# require "spec/matchers_2_spec.rb"
-# require "spec/shared_examples_spec.rb"
-# require "spec/main_spec.rb"
+require_specs


### PR DESCRIPTION
## Summary

This change will make `dr_spec` automatically `require` all spec files in `spec/**/*_spec.rb`, which is a handy feature from `rspec`.
Since DR does not allow to list files in a directory (I experimented with `$gtk.list_files`, but it doesn't work), the current implementation uses a system call to `ls`. This command is available on macOS and Linux, but not on Windows.

Unfortunately I don't have access to a Windows machine to make this work there as well, but hopefully a future contributor will help adjusting the implementation.

The README has also been updated, indicating this is only supported no Linux and macOS.