### PR TITLE
Decouple dr_spec from GTK::Assert (#65)

### DIFF
--- a/lib/dr_spec/core/dsl.rb
+++ b/lib/dr_spec/core/dsl.rb
@@ -33,7 +33,7 @@ end
 def xspecify(message, &block)
   world = DrSpec::World.instance
   group = world.current_group
-  noop  = Proc.new { |args, assert| }
+  noop  = Proc.new { }
   example = DrSpec::Example.new("xit_#{message}", group: group, block: noop, pending: true)
   group.add_example(example)
 end

--- a/lib/dr_spec/core/example.rb
+++ b/lib/dr_spec/core/example.rb
@@ -22,12 +22,19 @@ module DrSpec
       "#{group.full_description}_#{@description}"
     end
 
-    def run(args, assert)
+    def run(args = nil, assert = nil)
+      return DrSpec::Result.new(self, status: :pending) if pending?
+
       ctx_class = Class.new(DrSpec::ExampleContext)
-      ctx = ctx_class.new(assert)
-      group.collected_befores.each { |b| ctx.instance_exec(args, assert, &b) }
-      ctx.instance_exec(args, assert, &@block) unless pending?
-      group.collected_afters.each { |a| ctx.instance_exec(args, assert, &a) }
+      ctx = ctx_class.new
+      begin
+        group.collected_befores.each { |b| ctx.instance_exec(args, assert, &b) }
+        ctx.instance_exec(args, assert, &@block)
+        group.collected_afters.each { |a| ctx.instance_exec(args, assert, &a) }
+        DrSpec::Result.new(self, status: :passed)
+      rescue DrSpec::ExpectationFailed => e
+        DrSpec::Result.new(self, status: :failed, error: e)
+      end
     end
   end
 end

--- a/lib/dr_spec/core/example.rb
+++ b/lib/dr_spec/core/example.rb
@@ -22,15 +22,15 @@ module DrSpec
       "#{group.full_description}_#{@description}"
     end
 
-    def run(args = nil, assert = nil)
+    def run(args = nil)
       return DrSpec::Result.new(self, status: :pending) if pending?
 
       ctx_class = Class.new(DrSpec::ExampleContext)
       ctx = ctx_class.new
       begin
-        group.collected_befores.each { |b| ctx.instance_exec(args, assert, &b) }
-        ctx.instance_exec(args, assert, &@block)
-        group.collected_afters.each { |a| ctx.instance_exec(args, assert, &a) }
+        group.collected_befores.each { |b| ctx.instance_exec(args, &b) }
+        ctx.instance_exec(args, &@block)
+        group.collected_afters.each { |a| ctx.instance_exec(args, &a) }
         DrSpec::Result.new(self, status: :passed)
       rescue DrSpec::ExpectationFailed => e
         DrSpec::Result.new(self, status: :failed, error: e)

--- a/lib/dr_spec/core/example_context.rb
+++ b/lib/dr_spec/core/example_context.rb
@@ -1,11 +1,7 @@
 module DrSpec
   class ExampleContext
-    def initialize(assert)
-      @assertion_wrapper = AssertionWrapper.new(assert)
-    end
-
     def expect(subject)
-      @assertion_wrapper.expect(subject)
+      Expectation.new(subject)
     end
   end
 end

--- a/lib/dr_spec/core/expectation_failed.rb
+++ b/lib/dr_spec/core/expectation_failed.rb
@@ -1,0 +1,11 @@
+module DrSpec
+  class ExpectationFailed < StandardError
+    attr_reader :actual, :expected
+
+    def initialize(message, actual: nil, expected: nil)
+      @actual   = actual
+      @expected = expected
+      super(message)
+    end
+  end
+end

--- a/lib/dr_spec/core/result.rb
+++ b/lib/dr_spec/core/result.rb
@@ -1,0 +1,23 @@
+module DrSpec
+  class Result
+    attr_reader :example, :status, :error
+
+    def initialize(example, status:, error: nil)
+      @example = example
+      @status  = status  # :passed, :failed, :pending
+      @error   = error
+    end
+
+    def passed?
+      @status == :passed
+    end
+
+    def failed?
+      @status == :failed
+    end
+
+    def pending?
+      @status == :pending
+    end
+  end
+end

--- a/lib/dr_spec/core/utils.rb
+++ b/lib/dr_spec/core/utils.rb
@@ -2,29 +2,18 @@
 # NOTE if someone have a bettre name for this file please PR
 #
 #
-class AssertionWrapper
-  def initialize(assert)
-    @assert = assert
-  end
-
-  def expect(subject)
-    Expectation.new(subject, @assert)
-  end
-end
-
 class Expectation
-  def initialize(subject, assert)
+  def initialize(subject)
     @subject = subject
-    @assert = assert
   end
 
   def to(matcher)
-    matcher.match?(@assert, @subject)
+    matcher.match?(@subject)
     self
   end
 
   def not_to(matcher)
-    matcher.unmatch?(@assert, @subject)
+    matcher.unmatch?(@subject)
     self
   end
 

--- a/lib/dr_spec/core/world.rb
+++ b/lib/dr_spec/core/world.rb
@@ -47,7 +47,7 @@ module DrSpec
         group.each_example do |example|
           method_name = example.test_method_name
           Object.define_method(method_name) do |args, assert|
-            result = example.run(args, assert)
+            result = example.run(args)
             if result.passed?
               assert.ok!
             elsif result.failed?

--- a/lib/dr_spec/core/world.rb
+++ b/lib/dr_spec/core/world.rb
@@ -41,12 +41,19 @@ module DrSpec
     end
 
     # Phase 2: generate test_* methods on Object from the built tree
+    # Bridge: translates dr_spec Results into GTK::Assert calls
     def build_test_methods!
       @example_groups.each do |group|
         group.each_example do |example|
           method_name = example.test_method_name
           Object.define_method(method_name) do |args, assert|
-            example.run(args, assert)
+            result = example.run(args, assert)
+            if result.passed?
+              assert.ok!
+            elsif result.failed?
+              assert.true!(false, result.error.message)
+            end
+            # pending: no assert call → GTK marks as inconclusive
           end
         end
       end

--- a/lib/dr_spec/core_matchers.rb
+++ b/lib/dr_spec/core_matchers.rb
@@ -1,6 +1,3 @@
-# Boolean matchers
-#
-#
 class CoreMatcher
   def message custom_message
     if @fail_with == ""
@@ -15,13 +12,17 @@ class CoreMatcher
     @fail_with = fail_with
   end
 
-  def match? assert, value
+  def match? value
     boolean, text = positive_match? value
-    assert.true! boolean, message(text)
+    unless boolean
+      raise DrSpec::ExpectationFailed.new(message(text), actual: value, expected: @expected)
+    end
   end
 
-  def unmatch? assert, value
+  def unmatch? value
     boolean, text = positive_match? value
-    assert.false! boolean, "not_to : #{message(text)}"
+    if boolean
+      raise DrSpec::ExpectationFailed.new("not_to : #{message(text)}", actual: value, expected: @expected)
+    end
   end
 end

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -29,6 +29,8 @@ def run_specs
   end
 end
 
+require_relative "core/expectation_failed.rb"
+require_relative "core/result.rb"
 require_relative "core_matchers.rb"
 #
 require_relative "matchers/boolean_matchers.rb"

--- a/spec/architecture_spec.rb
+++ b/spec/architecture_spec.rb
@@ -2,16 +2,16 @@
 #
 spec :architecture_example_group do
   context "tree construction" do
-    specify "ExampleGroup has children and parent" do |args, assert|
+    specify "ExampleGroup has children and parent" do
       parent = DrSpec::ExampleGroup.new("parent")
       child  = DrSpec::ExampleGroup.new("child", parent: parent)
       parent.add_child(child)
-      assert.equal! child.parent, parent, "child should reference parent"
-      assert.equal! parent.children.length, 1, "parent should have 1 child"
-      assert.equal! parent.children[0], child, "parent's child should be the child"
+      expect(child.parent).to eq parent
+      expect(parent.children.length).to eq 1
+      expect(parent.children[0]).to eq child
     end
 
-    specify "full_description concatenates ancestor descriptions" do |args, assert|
+    specify "full_description concatenates ancestor descriptions" do
       root  = DrSpec::ExampleGroup.new("test_my_spec")
       mid   = DrSpec::ExampleGroup.new("when_something", parent: root)
       leaf  = DrSpec::ExampleGroup.new("and_nested", parent: mid)
@@ -22,7 +22,7 @@ spec :architecture_example_group do
   end
 
   context "collected_befores" do
-    specify "collects befores from root to leaf (parent first)" do |args, assert|
+    specify "collects befores from root to leaf (parent first)" do
       order = []
       root = DrSpec::ExampleGroup.new("root")
       root.add_before { order << :root }
@@ -33,10 +33,10 @@ spec :architecture_example_group do
 
       befores = grandchild.collected_befores
       befores.each { |b| b.call }
-      assert.equal! order, [:root, :child, :grandchild], "befores should run parent-first"
+      expect(order).to eq [:root, :child, :grandchild]
     end
 
-    specify "collected_afters runs from leaf to root" do |args, assert|
+    specify "collected_afters runs from leaf to root" do
       order = []
       root = DrSpec::ExampleGroup.new("root")
       root.add_after { order << :root }
@@ -45,7 +45,7 @@ spec :architecture_example_group do
 
       afters = child.collected_afters
       afters.each { |a| a.call }
-      assert.equal! order, [:child, :root], "afters should run child-first"
+      expect(order).to eq [:child, :root]
     end
   end
 end
@@ -57,14 +57,14 @@ spec :scope_isolation do
       @counter = 0
     end
 
-    specify "first test increments counter" do |args, assert|
+    specify "first test increments counter" do
       @counter += 10
-      assert.equal! @counter, 10, "counter should be 10"
+      expect(@counter).to eq 10
     end
 
-    specify "second test sees fresh counter (not 10)" do |args, assert|
+    specify "second test sees fresh counter (not 10)" do
       @counter += 1
-      assert.equal! @counter, 1, "counter should be 1, not 11 (isolated scope)"
+      expect(@counter).to eq 1
     end
   end
 
@@ -73,31 +73,28 @@ spec :scope_isolation do
       before do
         def helper_a; :a; end
       end
-      specify "can call helper_a" do |args, assert|
-        assert.equal! helper_a, :a, "helper_a should return :a"
+      specify "can call helper_a" do
+        expect(helper_a).to eq :a
       end
     end
 
     context "group B" do
-      specify "cannot see helper_a from group A" do |args, assert|
-        has_method = respond_to?(:helper_a)
-        assert.false! has_method, "helper_a should not be visible in group B"
+      specify "cannot see helper_a from group A" do
+        expect(respond_to?(:helper_a)).to be_falsy
       end
     end
   end
 end
 
 spec :world_introspection do
-  specify "World.instance has registered example groups" do |args, assert|
+  specify "World.instance has registered example groups" do
     world = DrSpec::World.instance
-    assert.true! world.example_groups.length > 0,
-      "World should have registered example groups"
+    expect(world.example_groups.length).to be_greater_than 0
   end
 
-  specify "World.instance has Metadata on groups" do |args, assert|
+  specify "World.instance has Metadata on groups" do
     world = DrSpec::World.instance
     group = world.example_groups.first
-    assert.true! group.metadata.is_a?(DrSpec::Metadata),
-      "group metadata should be a DrSpec::Metadata"
+    expect(group.metadata.is_a?(DrSpec::Metadata)).to be_truthy
   end
 end

--- a/spec/matchers_1_spec.rb
+++ b/spec/matchers_1_spec.rb
@@ -2,21 +2,17 @@
 #
 #focus_spec :string_matchers, tags: [:players] do
 spec :string_matchers, tags: [:players] do
-  #it "checks if a string starts with a specific prefix" do |args, assert|
-  specify "start_with" do |args, assert|
-
+  specify "start_with" do
     expect("Hello, world!").to start_with "Hello"
   end
-  #it "checks if a string ends with a specific suffix" do |args, assert|
-  specify "end_with" do |args, assert|
+  specify "end_with" do
     expect("Hello, world!").to end_with "world!"
   end
 end
 
 =begin
 spec :match do
-  #it "checks if a string matches a specific pattern" do |args, assert|
-  specify "match" do |args, assert|
+  specify "match" do
     expect("Hello, world!").to match /Hello/
   end
 end
@@ -25,19 +21,19 @@ end
 # Collection Matchers
 #
 spec :collection_matchers do
-  specify "checks if a collection is empty" do |args, assert|
+  specify "checks if a collection is empty" do
     expect([]           ).to be_empty
     expect([1, 2, 3]).not_to be_empty
   end
-  specify "checks if a collection contains a specific element" do |args, assert|
+  specify "checks if a collection contains a specific element" do
     expect([1, 2, 3]    ).to contain 2
     expect([1, 2, 3]).not_to contain 4
   end
-  specify "checks if a collection has a specific size" do |args, assert|
+  specify "checks if a collection has a specific size" do
     expect([1, 2, 3]    ).to have_size 3
     expect([1, 2, 3]).not_to have_size 4
   end
-   specify "checks if a collection includes elements in a specific order" do |args, assert|
+  specify "checks if a collection includes elements in a specific order" do
     expect([1, 2, 3]    ).to include_elements_in_order [1, 2, 3]
     expect([2, 1, 3]).not_to include_elements_in_order [1, 2, 3]
   end

--- a/spec/matchers_2_spec.rb
+++ b/spec/matchers_2_spec.rb
@@ -1,15 +1,6 @@
-# Available assertions:
-# assert.true!
-# assert.false!
-# assert.equal!
-# assert.exception!
-# assert.includes!
-# assert.not_includes!
-# assert.int!
-#
 spec :example do
-  specify "works" do |args, assert|
-    assert.equal!(5 + 5, 10)
+  specify "works" do
+    expect(5 + 5).to eq 10
   end
 end
 
@@ -20,9 +11,8 @@ spec :another_spec do
       @a = 4
     end
 
-    specify "expectation_3" do |args, assert|
-      puts "I'm the num 3"
-      puts @a = @a * 3
+    specify "expectation_3" do
+      @a = @a * 3
       expect(@a)
         .to(eq 12, fail_with: "nope 12")
         .and
@@ -33,34 +23,26 @@ spec :another_spec do
       before do
         @b = 5
       end
-      specify "expectation_4" do |args, assert|
-        puts "I'm the num 4"
-        puts @a = @a * 5 + @b
-        assert.equal! @a, 25, "nope 25"
+      specify "expectation_4" do
+        @a = @a * 5 + @b
+        expect(@a).to eq 25
       end
-      after do |args, assert|
+      after do
         @b = 6
-        puts "after 4"
         @a = 4 * 5 + @b
-        assert.equal! @a, 26, "nope 25"
+        expect(@a).to eq 26
       end
     end
 
-    after do |args, assert|
-      puts "after the_first_context"
-      puts @a
-      # FIX #53: @a was 26 in old architecture (scope leak from context_3).
-      # Now each test has its own ExampleContext:
-      #   - expectation_3's after sees @a=12 (only modified by its own it block)
-      #   - expectation_4's after sees @a=26 (modified by inner after, expected)
-      # See spec/architecture_spec.rb for isolation proof.
+    after do
+      # FIX #53: each test has its own ExampleContext, no scope leak.
     end
   end
 
 end
 
 spec "utilities function" do
-  specify :to_snake_case do |args, assert|
+  specify :to_snake_case do
     expect(to_snake_case("Hello World")          ).to eq "hello_world"
     expect(to_snake_case("AnotherExampleString") ).to eq "another_example_string"
     expect(to_snake_case("Snake Case Conversion")).to eq "snake_case_conversion"
@@ -74,19 +56,19 @@ end
 #
 #
 spec "Numeric Comparison matchers" do
-  specify "be greater than" do |args, assert|
+  specify "be greater than" do
     expect(10).to be_greater_than 5
     expect(10).not_to be_greater_than 10
   end
-  specify "be_greater_than_or_equal_to" do |args, assert|
+  specify "be_greater_than_or_equal_to" do
     expect(10).to be_greater_than_or_equal_to 10
-    expect(10).not_to be_greater_than_or_equal_to 11 # ???? TODO test in deep
+    expect(10).not_to be_greater_than_or_equal_to 11
   end
-  specify "be_less_than" do |args, assert|
+  specify "be_less_than" do
     expect(5).to be_less_than 10
     expect(5).not_to be_less_than 4
   end
-  specify "be_less_than_or_equal_to" do |args, assert|
+  specify "be_less_than_or_equal_to" do
     expect(5).to be_less_than_or_equal_to 5
     expect(5).not_to be_less_than_or_equal_to 4
   end
@@ -96,15 +78,15 @@ end
 #
 #
 spec :boolean_matchers do
-  specify "be_truthy" do |args, assert|
+  specify "be_truthy" do
     expect(true).to be_truthy
     expect(false).not_to be_truthy
   end
-  specify "be_falsy" do |args, assert|
+  specify "be_falsy" do
     expect(false).to be_falsy
     expect(true).not_to be_falsy
   end
-  specify "be_nil" do |args, assert|
+  specify "be_nil" do
     expect(nil).to be_nil
     expect(true).not_to be_nil
   end


### PR DESCRIPTION
## Summary

- **Replace `assert.true!`/`assert.false!`** with `DrSpec::ExpectationFailed` exceptions throughout the matcher chain
- **Remove `|args, assert|`** from all spec block signatures — specs are now pure dr_spec
- **`assert` confined** to a single GTK bridge line in `World#build_test_methods!`

## New classes

- `DrSpec::ExpectationFailed` — raised on matcher failure
- `DrSpec::Result` — stores pass/fail/pending + error per example

## Before / After

```ruby
# Before (coupled to GTK::Assert)
specify "test" do |args, assert|
  assert.equal! 1 + 1, 2, "math"
end

# After (standalone)
specify "test" do
  expect(1 + 1).to eq 2
end
```

## Chain

```
CoreMatcher#match?(value) → raise ExpectationFailed
  → Example#run catches → DrSpec::Result
    → World bridge → assert.ok! (GTK compat)
```

## Test plan

- [x] 32 tests pass on DR 2024
- [x] 32 tests pass on DR 6.51
- [x] Lefthook 3/3 (rubocop, reek, dr_spec)
- [x] Failure reporting verified (ExpectationFailed → red output + test-failures.txt)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)