### PR TITLE
Tick-based testing: MoveGame proof of concept (#58)

### DIFF
--- a/app/tests.rb
+++ b/app/tests.rb
@@ -9,6 +9,7 @@ require "spec/matchers_1_spec.rb"
 require "spec/matchers_2_spec.rb"
 require "spec/shared_examples_spec.rb"
 require "spec/architecture_spec.rb"
+require "spec/tick_based_spec.rb"
 require "spec/main_spec.rb"
 
 puts "Test where run"

--- a/bin/dr_spec_quiet
+++ b/bin/dr_spec_quiet
@@ -8,9 +8,11 @@
 # Échec:  "dr_spec: 2 test(s) failed\n  🔴 test_name - reason"
 
 require "open3"
+require "timeout"
 
 DR_BIN = ENV["DRAGONRUBY_BIN"] || File.expand_path("../../../dragonruby-macos/dragonruby", __dir__)
 PROJECT = File.expand_path("..", __dir__)
+DR_TIMEOUT = Integer(ENV["DR_SPEC_TIMEOUT"] || 30)
 
 cmd = [
   DR_BIN, PROJECT,
@@ -19,7 +21,18 @@ cmd = [
   "--exit-on-fail"
 ]
 
-stdout, stderr, status = Open3.capture3(*cmd)
+stdout = stderr = ""
+status = nil
+begin
+  Timeout.timeout(DR_TIMEOUT) do
+    stdout, stderr, status = Open3.capture3(*cmd)
+  end
+rescue Timeout::Error
+  # Kill any stuck DragonRuby process
+  system("pkill -9 -f '#{DR_BIN}.*#{PROJECT}'")
+  puts "dr_spec: timeout after #{DR_TIMEOUT}s (DragonRuby did not exit)"
+  exit 1
+end
 output = stdout + stderr
 
 # Extract summary lines

--- a/spec/fixtures/move_game.rb
+++ b/spec/fixtures/move_game.rb
@@ -1,0 +1,26 @@
+# Minimal game for tick-based testing
+# A player moves right each tick and stops at a wall.
+class MoveGame
+  attr_gtk
+
+  def initialize
+    @started = false
+  end
+
+  def tick
+    defaults unless @started
+
+    state.player.x += state.player.speed
+    if state.player.x >= state.wall_x
+      state.player.x = state.wall_x
+    end
+  end
+
+  def defaults
+    state.player.x     ||= 0
+    state.player.y     ||= 360
+    state.player.speed ||= 5
+    state.wall_x       ||= 100
+    @started = true
+  end
+end

--- a/spec/tick_based_spec.rb
+++ b/spec/tick_based_spec.rb
@@ -1,0 +1,34 @@
+# Tick-based testing proof of concept
+# Tests a MoveGame by calling tick manually.
+
+require "spec/fixtures/move_game.rb"
+
+spec :tick_based_testing do
+  before do
+    @game = MoveGame.new
+    @game.args = $gtk.args
+    # Reset state for isolation
+    @game.state.player.x     = 0
+    @game.state.player.y     = 360
+    @game.state.player.speed = 5
+    @game.state.wall_x       = 100
+  end
+
+  specify "game can be instantiated" do
+    expect(@game).not_to be_nil
+  end
+
+  specify "player starts at x=0" do
+    expect(@game.state.player.x).to eq 0
+  end
+
+  specify "player moves after 10 ticks" do
+    10.times { @game.tick }
+    expect(@game.state.player.x).to eq 50
+  end
+
+  specify "player stops at wall" do
+    200.times { @game.tick }
+    expect(@game.state.player.x).to eq 100
+  end
+end


### PR DESCRIPTION
## Summary

Proves dr_spec can test DragonRuby games **tick by tick** without any new API — just `before` + `n.times { game.tick }` + `expect`.

### Pattern

```ruby
spec :tick_based_testing do
  before do
    @game = MoveGame.new
    @game.args = $gtk.args
    @game.state.player.x = 0
    @game.state.player.speed = 5
    @game.state.wall_x = 100
  end

  specify "player moves after 10 ticks" do
    10.times { @game.tick }
    expect(@game.state.player.x).to eq 50
  end

  specify "player stops at wall" do
    200.times { @game.tick }
    expect(@game.state.player.x).to eq 100
  end
end
```

### Also included

- `bin/dr_spec_quiet` timeout protection (30s default, `DR_SPEC_TIMEOUT` env var) to prevent stuck DragonRuby processes from accumulating

## Test plan

- [x] 36 tests pass on DR 2024
- [x] 36 tests pass on DR 6.51
- [x] Lefthook 3/3

Addresses #58 (basic tick-based testing). Input simulation (#69) is a separate layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)