### PR TITLE
Add GitHub Actions CI (#62)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [dr_spec_2, develop, master]
+  pull_request:
+    branches: [dr_spec_2, develop, master]
+
+jobs:
+  lint:
+    name: Rubocop & Reek
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Rubocop
+        run: bundle exec rubocop app lib spec
+
+      - name: Reek
+        run: bundle exec reek app lib || true
+
+  test:
+    name: dr_spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download DragonRuby
+        uses: kfischer-okarin/download-dragonruby@v1
+        with:
+          version: 'latest'
+          license_tier: 'standard'
+
+      - name: Run dr_spec
+        env:
+          SDL_VIDEODRIVER: dummy
+          SDL_AUDIODRIVER: dummy
+        run: |
+          chmod u+x ./dragonruby
+          ./dragonruby . --eval app/tests.rb --no-tick --exit-on-fail 2>&1 | tee tests.log
+          grep '0 ➖ test(s) failed' tests.log


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI mirroring the lefthook setup, based on the dr_mod CI workflow.

### Jobs (parallel)

| Job | What | Blocking? |
|-----|------|-----------|
| `lint` | rubocop + reek | rubocop yes, reek no |
| `test` | dr_spec via DragonRuby headless | yes |

### DR headless setup

- Uses `kfischer-okarin/download-dragonruby@v1` to get the binary
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy` for headless
- `--exit-on-fail` ensures exit code 1 on failure
- `grep '0 ➖ test(s) failed'` as safety net

### Triggers

Push/PR to `dr_spec_2`, `develop`, `master`.

## Test plan

- [x] Workflow YAML validates
- [x] Mirrors working dr_mod CI setup
- [ ] Will validate on first PR push to dr_spec_2

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)