### PR TITLE
Add French documentation (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A simple DSL and test runner DragonRuby Game Toolkit (DRGTK).
 It try to mimic rspec.
 
+🇫🇷 [Documentation en français](docs/fr/README.md)
+
 [New to writing tests? Check out this tutorial introducing the concept in DRGTK!](https://www.dragonriders.community/recipes/testing)
 
 🚧 **dr_spec is a work in progress! It works, but the interfaces may change.** 🚧

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,0 +1,17 @@
+# Documentation dr_spec (FR)
+
+Bienvenue dans la documentation francophone de dr_spec, un framework de test RSpec-like pour DragonRuby Game Toolkit.
+
+## Sommaire
+
+- [Guide d'utilisation](guide_utilisation.md) — Installation, syntaxe, lancer les tests
+- [Matchers](matchers.md) — Référence complète de tous les matchers
+- [Shared Examples](shared_examples.md) — `shared_examples`, `it_behaves_like`, `include_examples`
+- [Architecture](architecture.md) — Fonctionnement interne du framework (2-pass class-based)
+- [Roadmap](roadmap.md) — Vision, prochaines fonctionnalités, comment contribuer
+
+## Liens utiles
+
+- [README principal (EN)](../../README.md)
+- [Issues GitHub](https://github.com/levaleureux/dr_spec/issues)
+- [DragonRuby Game Toolkit](https://dragonruby.org/)

--- a/docs/fr/guide_utilisation.md
+++ b/docs/fr/guide_utilisation.md
@@ -1,0 +1,166 @@
+# Guide d'utilisation
+
+## Installation
+
+### Manuellement
+
+1. Copiez le dossier `lib/dr_spec` dans votre projet DragonRuby
+2. Dans votre `app/main.rb` ou `app/test.rb`, ajoutez :
+
+```ruby
+require "lib/dr_spec/dragon_specs.rb"
+```
+
+### Avec Smaug
+
+Ajoutez dans votre `Smaug.toml` :
+
+```toml
+dr_spec = { repo = "https://github.com/levaleureux/dr_spec" }
+```
+
+Puis `smaug install` et :
+
+```ruby
+require "smaug/dr_spec/lib/dr_spec/dragon_specs"
+```
+
+## Lancer les tests
+
+### En local
+
+```bash
+./dragonruby . --eval app/tests.rb --no-tick
+```
+
+### Avec Smaug
+
+```bash
+smaug run --test spec/main.rb
+```
+
+### En CI
+
+Voir la section [CI du README principal](../../README.md#in-ci-github-actions).
+
+## Syntaxe de base
+
+### spec et context
+
+`spec` définit un groupe de tests. `context` crée un sous-groupe pour organiser les cas de test.
+
+```ruby
+spec "MonObjet" do
+  context "quand il est initialisé" do
+    specify "a une valeur par défaut" do
+      expect(MonObjet.new.valeur).to eq 0
+    end
+  end
+end
+```
+
+Les descriptions acceptent des `:symboles` ou des `"strings"`.
+
+### specify
+
+`specify` (alias de `it`) définit un test individuel.
+
+```ruby
+specify "additionne deux nombres" do
+  expect(2 + 3).to eq 5
+end
+```
+
+> **Note :** `it` est un mot réservé en Ruby 3.4+ (DragonRuby 6.x). Utilisez `specify` à la place.
+
+### xspecify (test en attente)
+
+Préfixez avec `x` pour marquer un test comme pending (il ne sera pas exécuté) :
+
+```ruby
+xspecify "fonctionnalité future" do
+  expect(true).to eq true
+end
+```
+
+### focus_spec
+
+Pour n'exécuter qu'un seul groupe de tests pendant le développement :
+
+```ruby
+focus_spec "mon test en cours" do
+  specify "ce que je debugge" do
+    expect(1).to eq 1
+  end
+end
+```
+
+## Hooks : before et after
+
+`before` s'exécute avant chaque test du groupe. `after` s'exécute après. Ils sont hérités par les contextes enfants.
+
+```ruby
+spec "avec hooks" do
+  before do
+    @joueur = Joueur.new
+  end
+
+  specify "le joueur existe" do
+    expect(@joueur).not_to be_nil
+  end
+
+  context "après un mouvement" do
+    before do
+      @joueur.move(10, 0)
+    end
+
+    specify "la position x change" do
+      expect(@joueur.x).to eq 10
+    end
+  end
+
+  after do
+    # nettoyage si nécessaire
+  end
+end
+```
+
+L'ordre d'exécution : befores du parent → befores de l'enfant → test → afters de l'enfant → afters du parent.
+
+## Assertions : expect / to / not_to
+
+```ruby
+expect(valeur).to matcher
+expect(valeur).not_to matcher
+```
+
+### Chaînage avec .and
+
+```ruby
+expect(10)
+  .to(eq 10)
+  .and
+  .to(be_greater_than 5)
+```
+
+### Message d'erreur personnalisé
+
+Tous les matchers acceptent `fail_with:` :
+
+```ruby
+expect(score).to eq 100, fail_with: "le score devrait être 100"
+```
+
+## Blocs (pour raise_error)
+
+Pour tester les erreurs, passez un bloc à `expect` :
+
+```ruby
+expect { methode_dangereuse }.to raise_error
+expect { 1 + 1 }.not_to raise_error
+```
+
+## Voir aussi
+
+- [Matchers](matchers.md) — référence complète
+- [Shared Examples](shared_examples.md) — factoriser les tests

--- a/docs/fr/matchers.md
+++ b/docs/fr/matchers.md
@@ -1,0 +1,146 @@
+# Référence des Matchers
+
+Tous les matchers supportent `to` et `not_to`, et acceptent un paramètre optionnel `fail_with:` pour personnaliser le message d'erreur.
+
+## Égalité
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `eq(expected)` | Vérifie l'égalité (`==`) | `matchers/matchers.rb` |
+
+```ruby
+expect(1 + 1).to eq 2
+expect("foo").not_to eq "bar"
+```
+
+## Comparaison numérique
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `be_greater_than(n)` | Vérifie `> n` | `matchers/numeric_comparison_matchers.rb` |
+| `be_greater_than_or_equal_to(n)` | Vérifie `>= n` | |
+| `be_less_than(n)` | Vérifie `< n` | |
+| `be_less_than_or_equal_to(n)` | Vérifie `<= n` | |
+
+```ruby
+expect(10).to be_greater_than 5
+expect(5).to be_less_than_or_equal_to 5
+```
+
+## Booléens
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `be_truthy` | Vérifie que la valeur est `true` | `matchers/boolean_matchers.rb` |
+| `be_falsy` | Vérifie que la valeur est falsy (`false` ou `nil`) | |
+| `be_nil` | Vérifie que la valeur est `nil` | |
+
+```ruby
+expect(true).to be_truthy
+expect(nil).to be_nil
+expect(false).to be_falsy
+```
+
+## Type
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `be_instance_of(klass)` | Vérifie la classe exacte | `matchers/type_matchers.rb` |
+| `be_kind_of(klass)` | Vérifie la classe ou un ancêtre | |
+
+```ruby
+expect("hello").to be_instance_of(String)
+expect(1).to be_kind_of(Numeric)
+```
+
+## Collection
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `include(element)` | Vérifie qu'un élément est présent | `matchers/collection_matchers.rb` |
+| `contain(element)` | Alias de `include` | |
+| `contain_exactly(array)` | Vérifie les mêmes éléments (ordre quelconque) | |
+| `include_elements_in_order(array)` | Vérifie les éléments dans l'ordre | |
+| `have_size(n)` | Vérifie la taille | |
+| `be_empty` | Vérifie que la collection est vide | |
+
+```ruby
+expect([1, 2, 3]).to include 2
+expect([3, 1, 2]).to contain_exactly [1, 2, 3]
+expect([1, 2, 3]).to include_elements_in_order [1, 2]
+expect([1, 2]).to have_size 2
+expect([]).to be_empty
+```
+
+## String
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `start_with(string)` | Vérifie le préfixe | `matchers/string_matchers.rb` |
+| `end_with(string)` | Vérifie le suffixe | |
+| `match(regex)` | Vérifie une expression régulière | |
+
+```ruby
+expect("hello world").to start_with "hello"
+expect("hello world").to end_with "world"
+expect("abc123").to match(/\d+/)
+```
+
+## Erreur
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `raise_error` | Vérifie qu'un bloc lève une erreur | `matchers/error_matchers.rb` |
+| `raise_error(ErrorClass)` | Vérifie le type d'erreur | |
+
+Nécessite un bloc avec `expect { ... }` :
+
+```ruby
+expect { raise "boom" }.to raise_error
+expect { raise ArgumentError, "bad" }.to raise_error(ArgumentError)
+expect { 1 + 1 }.not_to raise_error
+```
+
+## Objet
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `respond_to(:method_name)` | Vérifie qu'un objet répond à une méthode | `matchers/object_matchers.rb` |
+
+```ruby
+expect("hello").to respond_to(:length)
+expect([1, 2]).to respond_to(:push)
+```
+
+## Custom
+
+| Matcher | Description | Source |
+|---------|-------------|--------|
+| `satisfy { \|v\| ... }` | Vérifie une condition personnalisée via un bloc | `matchers/satisfy_matcher.rb` |
+
+```ruby
+expect(10).to satisfy { |v| v > 5 }
+expect(42).to satisfy { |v| v.even? && v > 10 }
+```
+
+## Créer son propre matcher
+
+Héritez de `CoreMatcher` et implémentez `positive_match?(actual)` :
+
+```ruby
+class MonMatcher < CoreMatcher
+  def positive_match?(actual)
+    [actual == @expected, "#{actual} n'est pas égal à #{@expected}"]
+  end
+end
+
+def mon_matcher(expected, fail_with: "")
+  MonMatcher.new(expected, fail_with)
+end
+```
+
+Utilisez-le ensuite comme n'importe quel matcher :
+
+```ruby
+expect(valeur).to mon_matcher(42)
+```

--- a/docs/fr/roadmap.md
+++ b/docs/fr/roadmap.md
@@ -1,0 +1,44 @@
+# Roadmap
+
+## Implémenté
+
+- [x] DSL RSpec-like : `spec`, `context`, `specify`, `before`, `after`
+- [x] Architecture class-based 2-pass (fix scope isolation #53)
+- [x] Matchers : `eq`, booléens, numériques, string, collection, type, error, object, satisfy
+- [x] Shared examples : `shared_examples`, `it_behaves_like`, `include_examples`
+- [x] `xspecify` (tests pending)
+- [x] `focus_spec` (exécuter un seul groupe)
+- [x] Chaînage `.and` pour les assertions
+- [x] `fail_with:` messages personnalisés
+- [x] Output formaté avec couleurs ANSI
+- [x] Tick-based testing (simulation de ticks DragonRuby)
+- [x] CI GitHub Actions
+
+## En cours
+
+- [ ] Tags et filtrage ([#7](https://github.com/levaleureux/dr_spec/issues/7)) — `metadata.rb` commencé
+- [ ] Doc reporter format ([#72](https://github.com/levaleureux/dr_spec/issues/72))
+
+## Prévu
+
+- [ ] Syntaxe `let` ([#71](https://github.com/levaleureux/dr_spec/issues/71))
+- [ ] Mocking d'objets ([#4](https://github.com/levaleureux/dr_spec/issues/4))
+- [ ] Agrégation des failures ([#8](https://github.com/levaleureux/dr_spec/issues/8))
+- [ ] Logging / rerun des tests échoués ([#6](https://github.com/levaleureux/dr_spec/issues/6))
+- [ ] Code coverage ([#59](https://github.com/levaleureux/dr_spec/issues/59))
+- [ ] Compatibilité Smaug ([#78](https://github.com/levaleureux/dr_spec/issues/78))
+
+## Vision long terme
+
+- [ ] Scenario runner Capybara-like ([#58](https://github.com/levaleureux/dr_spec/issues/58))
+- [ ] Syntaxe BDD/Gherkin Turnip-like ([#57](https://github.com/levaleureux/dr_spec/issues/57))
+- [ ] Simulation d'inputs ([#69](https://github.com/levaleureux/dr_spec/issues/69))
+
+## Comment contribuer
+
+1. Forkez le repo
+2. Créez une branche `feature/xxx` depuis `dr_spec_2`
+3. Développez avec des tests
+4. Ouvrez une PR vers `dr_spec_2`
+
+Les issues marquées comme ouvertes sont un bon point de départ. Voir les [issues sur GitHub](https://github.com/levaleureux/dr_spec/issues).

--- a/docs/fr/shared_examples.md
+++ b/docs/fr/shared_examples.md
@@ -1,0 +1,110 @@
+# Shared Examples
+
+Les shared examples permettent de factoriser des tests réutilisables entre plusieurs contextes.
+
+## Définir des shared examples
+
+```ruby
+shared_examples "un objet avec des coordonnées" do
+  specify "a un x" do
+    expect(@objet.x).not_to be_nil
+  end
+
+  specify "a un y" do
+    expect(@objet.y).not_to be_nil
+  end
+end
+```
+
+## it_behaves_like
+
+Crée un sous-contexte qui inclut les shared examples. Les tests apparaissent dans un contexte nommé d'après le shared.
+
+```ruby
+spec "Point" do
+  before do
+    @objet = Point.new(10, 20)
+  end
+
+  it_behaves_like "un objet avec des coordonnées"
+end
+
+spec "Joueur" do
+  before do
+    @objet = Joueur.new(0, 0)
+  end
+
+  it_behaves_like "un objet avec des coordonnées"
+end
+```
+
+Output :
+
+```
+✅ test_Point_un objet avec des coordonnées_a un x
+✅ test_Point_un objet avec des coordonnées_a un y
+✅ test_Joueur_un objet avec des coordonnées_a un x
+✅ test_Joueur_un objet avec des coordonnées_a un y
+```
+
+## include_examples
+
+Fusionne les shared examples directement dans le contexte courant (sans créer de sous-contexte).
+
+```ruby
+spec "Widget" do
+  before do
+    @objet = Widget.new(5, 5)
+  end
+
+  include_examples "un objet avec des coordonnées"
+
+  specify "a une taille" do
+    expect(@objet.size).to be_greater_than 0
+  end
+end
+```
+
+Output :
+
+```
+✅ test_Widget_a un x
+✅ test_Widget_a un y
+✅ test_Widget_a une taille
+```
+
+## it_behaves_like vs include_examples
+
+| | `it_behaves_like` | `include_examples` |
+|---|---|---|
+| Crée un sous-contexte | Oui | Non |
+| Isolation | Les tests sont dans leur propre groupe | Les tests sont au même niveau |
+| Output | Préfixé par le nom du shared | Directement dans le contexte parent |
+
+En général, préférez `it_behaves_like` pour la clarté de l'output. Utilisez `include_examples` quand vous voulez que les tests apparaissent au même niveau que les autres tests du contexte.
+
+## Exemple complet
+
+```ruby
+shared_examples "un conteneur" do
+  specify "n'est pas vide" do
+    expect(@conteneur).not_to be_empty
+  end
+
+  specify "a une taille" do
+    expect(@conteneur).to respond_to(:size)
+  end
+end
+
+spec "Array comme conteneur" do
+  before do
+    @conteneur = [1, 2, 3]
+  end
+
+  it_behaves_like "un conteneur"
+
+  specify "supporte push" do
+    expect(@conteneur).to respond_to(:push)
+  end
+end
+```


### PR DESCRIPTION
## Summary
- Add `docs/fr/` with 5 documents: index, guide d'utilisation, matchers, shared examples, roadmap
- Add 🇫🇷 link in main README header
- `architecture.md` was already present, now linked from the index

## Docs created
- `docs/fr/README.md` — index/sommaire
- `docs/fr/guide_utilisation.md` — install, syntaxe, hooks, assertions
- `docs/fr/matchers.md` — référence complète avec exemples et liens source
- `docs/fr/shared_examples.md` — guide it_behaves_like vs include_examples
- `docs/fr/roadmap.md` — état des features, issues liées, comment contribuer

## Test plan
- [ ] Review rendered markdown on GitHub
- [ ] Verify all internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)