### PR TITLE
Fix: hook exception crashes entire runner (#81)

### DIFF
--- a/app/tests.rb
+++ b/app/tests.rb
@@ -10,6 +10,7 @@ require "spec/matchers_2_spec.rb"
 require "spec/shared_examples_spec.rb"
 require "spec/architecture_spec.rb"
 require "spec/matchers_3_spec.rb"
+require "spec/hook_exception_spec.rb"
 require "spec/tick_based_spec.rb"
 require "spec/main_spec.rb"
 

--- a/lib/dr_spec/core/example.rb
+++ b/lib/dr_spec/core/example.rb
@@ -34,6 +34,8 @@ module DrSpec
         DrSpec::Result.new(self, status: :passed)
       rescue DrSpec::ExpectationFailed => e
         DrSpec::Result.new(self, status: :failed, error: e)
+      rescue => e
+        DrSpec::Result.new(self, status: :failed, error: e)
       end
     end
   end

--- a/spec/hook_exception_spec.rb
+++ b/spec/hook_exception_spec.rb
@@ -1,0 +1,42 @@
+# Hook exception handling tests (#81)
+#
+# Verify that exceptions in before/after hooks don't crash the runner.
+# We test this by running examples directly and checking their Result status.
+#
+
+spec "hook exception handling" do
+  specify "before hook RuntimeError produces failed result" do
+    group = DrSpec::ExampleGroup.new("test_group")
+    group.add_before { raise "boom in before" }
+
+    example = DrSpec::Example.new("test", group: group, block: proc { })
+    result = example.run
+
+    expect(result.failed?).to be_truthy
+  end
+
+  specify "after hook RuntimeError produces failed result" do
+    group = DrSpec::ExampleGroup.new("test_group")
+    group.add_after { raise "boom in after" }
+
+    example = DrSpec::Example.new("test", group: group, block: proc { })
+    result = example.run
+
+    expect(result.failed?).to be_truthy
+  end
+
+  specify "before hook NoMethodError produces failed result" do
+    group = DrSpec::ExampleGroup.new("test_group")
+    group.add_before { nil.nonexistent_method }
+
+    example = DrSpec::Example.new("test", group: group, block: proc { })
+    result = example.run
+
+    expect(result.failed?).to be_truthy
+  end
+
+  specify "runner continues after hook errors" do
+    # If we reach this test, the runner did not crash
+    expect(1 + 1).to eq 2
+  end
+end


### PR DESCRIPTION
## Summary
- Fix critical bug: exceptions in before/after hooks (RuntimeError, NoMethodError...) crashed the entire runner
- Add `rescue => e` in `Example#run` to wrap unexpected errors in a failed `Result`
- Add 4 tests verifying hook exception handling

## Before this fix
A single broken `before` or `after` hook would abort the entire test suite.

## After this fix
Broken hooks report as individual test failures. The runner continues executing remaining tests.

## Test plan
- [x] 53 tests, 0 failures
- [x] Lefthook passes (rubocop, reek, dr_spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)