### PR TITLE
Add type matchers specs (#73)

### DIFF
--- a/app/tests.rb
+++ b/app/tests.rb
@@ -10,6 +10,7 @@ require "spec/matchers_2_spec.rb"
 require "spec/shared_examples_spec.rb"
 require "spec/architecture_spec.rb"
 require "spec/matchers_3_spec.rb"
+require "spec/type_matchers_spec.rb"
 require "spec/tick_based_spec.rb"
 require "spec/main_spec.rb"
 

--- a/spec/type_matchers_spec.rb
+++ b/spec/type_matchers_spec.rb
@@ -1,0 +1,37 @@
+# Type matchers tests (#73)
+#
+#
+
+spec "type matchers" do
+  context "be_instance_of" do
+    specify "passes for exact class" do
+      expect("hello").to be_instance_of(String)
+    end
+
+    specify "passes for Integer" do
+      expect(42).to be_instance_of(Integer)
+    end
+
+    specify "passes for Array" do
+      expect([1, 2]).to be_instance_of(Array)
+    end
+
+    specify "fails for wrong class" do
+      expect("hello").not_to be_instance_of(Integer)
+    end
+  end
+
+  context "be_kind_of" do
+    specify "passes for parent class" do
+      expect(42).to be_kind_of(Numeric)
+    end
+
+    specify "passes for exact class" do
+      expect("hello").to be_kind_of(String)
+    end
+
+    specify "fails for unrelated class" do
+      expect("hello").not_to be_kind_of(Numeric)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add 7 tests for `be_instance_of` and `be_kind_of` matchers
- Covers exact class, parent class (Numeric), and negative paths

## Test plan
- [x] 56 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)