### PR TITLE
Add tests for include and contain_exactly matchers (#82)

### DIFF
--- a/spec/matchers_1_spec.rb
+++ b/spec/matchers_1_spec.rb
@@ -10,13 +10,8 @@ spec :string_matchers, tags: [:players] do
   end
 end
 
-=begin
-spec :match do
-  specify "match" do
-    expect("Hello, world!").to match /Hello/
-  end
-end
-=end
+# NOTE: match (regex) matcher cannot be tested — DragonRuby/mruby
+# does not include Regexp by default. See #82.
 
 # Collection Matchers
 #
@@ -32,6 +27,14 @@ spec :collection_matchers do
   specify "checks if a collection has a specific size" do
     expect([1, 2, 3]    ).to have_size 3
     expect([1, 2, 3]).not_to have_size 4
+  end
+  specify "checks if a collection includes an element" do
+    expect([1, 2, 3]).to include 2
+    expect([1, 2, 3]).not_to include 4
+  end
+  specify "checks if a collection contains exactly the same elements" do
+    expect([3, 1, 2]).to contain_exactly [1, 2, 3]
+    expect([1, 2, 3]).not_to contain_exactly [1, 2]
   end
   specify "checks if a collection includes elements in a specific order" do
     expect([1, 2, 3]    ).to include_elements_in_order [1, 2, 3]


### PR DESCRIPTION
## Summary
- Add tests for `include` and `contain_exactly` matchers (positive + negative paths)
- Note: `match` (regex) matcher cannot be tested — DragonRuby/mruby does not include Regexp

## Test plan
- [x] 51 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)