### PR TITLE
Add doc reporter format (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,12 +397,67 @@ tmp/
 - **No automatic file discovery** — mruby has no `Dir.glob`, files must be loaded via `require`
 - **No Regexp** — mruby doesn't include Regexp; the instrumenter uses string comparisons
 
-## Outputs
+## Output formats
 
-There is on this project a will to make a very fast and readable output
+dr_spec ships with 3 built-in reporters. Pass a CLI flag or use `run_specs(reporter:)`.
 
-<img src="image.png" alt="some output" width="300">
+### Dots (default)
 
+Compact output, one character per test:
+
+```bash
+./dragonruby . --eval app/tests.rb --no-tick
+```
+
+```
+..........F..P..
+100 ✅ test(s) passed
+ 2 🔀 test(s) pending
+ 1 ❌ test(s) failed
+```
+
+### Doc (`--doc`)
+
+RSpec-style documentation with indented spec tree:
+
+```bash
+./dragonruby . --eval app/tests.rb --no-tick --doc
+```
+
+```
+string_matchers
+  ✅ start_with
+  ✅ end_with
+architecture
+  example_group
+    tree construction
+      ✅ ExampleGroup has children and parent
+      ✅ full_description concatenates ancestor descriptions
+  scope_isolation
+    each it block gets its own ExampleContext
+      ✅ first test increments counter
+
+100 passed, 2 pending
+```
+
+### Quiet (`--quiet`)
+
+Minimal output for CI scripts:
+
+```bash
+./dragonruby . --eval app/tests.rb --no-tick --quiet
+```
+
+```
+dr_spec: 100 test(s) passed
+```
+
+### Programmatic usage
+
+```ruby
+run_specs(reporter: DrSpec::Reporters::Doc.new)
+run_specs(reporter: DrSpec::Reporters::Quiet.new)
+```
 
 ## Contributing
 
@@ -414,18 +469,17 @@ This project uses [git flow](https://danielkummer.github.io/git-flow-cheatsheet/
 |--------|------|
 | `master` | Stable releases only |
 | `develop` | Main development branch |
-| `dr_spec_2` | **Transition branch** for the v2 rewrite (temporary, will merge into `develop`) |
-| `feature/*` | Feature branches, created from `dr_spec_2` (during transition) or `develop` |
+| `feature/*` | Feature branches, created from `develop` |
 
 ### How to contribute
 
 1. Fork the repo
-2. Create a feature branch from `dr_spec_2` (during v2 transition) or `develop`:
+2. Create a feature branch from `develop`:
    ```bash
-   git checkout -b feature/my-feature origin/dr_spec_2
+   git checkout -b feature/my-feature origin/develop
    ```
 3. Write your code and tests
-4. Push and open a PR targeting `dr_spec_2` (or `develop` after v2 is released)
+4. Push and open a PR targeting `develop`
 
 **Never commit directly to `master`.** All changes go through `feature/* → develop → master`.
 

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -1,10 +1,11 @@
 $gtk.log_level = :on
 
-def run_specs
+def run_specs(reporter: nil)
   puts "================      running tests ========="
   puts "💨 running tests"
 
-  runner = DrSpec::Runner.new
+  reporter ||= select_reporter
+  runner = DrSpec::Runner.new(reporter: reporter)
   runner.run
 
   DrSpec::Coverage.report
@@ -49,6 +50,7 @@ require_relative "tests_formater.rb"
 require_relative "core/reporter.rb"
 require_relative "reporters/dots.rb"
 require_relative "reporters/quiet.rb"
+require_relative "reporters/doc.rb"
 require_relative "core/runner.rb"
 require_relative "coverage/tracker.rb"
 require_relative "coverage/instrumenter.rb"
@@ -57,3 +59,14 @@ require_relative "coverage/html_helpers.rb"
 require_relative "coverage/html_style.rb"
 require_relative "coverage/html_reporter.rb"
 require_relative "coverage/coverage.rb"
+
+def select_reporter
+  args = $gtk.cli_arguments.keys.map(&:to_s)
+  if args.include?("doc") || args.include?("format-doc")
+    DrSpec::Reporters::Doc.new
+  elsif args.include?("quiet")
+    DrSpec::Reporters::Quiet.new
+  else
+    DrSpec::Reporters::Dots.new
+  end
+end

--- a/lib/dr_spec/reporters/doc.rb
+++ b/lib/dr_spec/reporters/doc.rb
@@ -1,0 +1,80 @@
+module DrSpec
+  module Reporters
+    class Doc < DrSpec::Reporter
+      def initialize
+        @current_groups = []
+      end
+
+      def report_example(result)
+        groups = ancestor_chain(result.example.group)
+        print_group_transitions(groups)
+        print_example(result, groups.length)
+      end
+
+      def report_summary(results)
+        puts ""
+        print_counts(results)
+        print_failures(results)
+      end
+
+      private
+
+      def ancestor_chain(group)
+        chain = []
+        current = group
+        while current
+          chain.unshift(current)
+          current = current.parent
+        end
+        chain
+      end
+
+      def print_group_transitions(groups)
+        groups.each_with_index do |group, depth|
+          next if depth < @current_groups.length && @current_groups[depth] == group
+
+          indent = "  " * depth
+          puts "#{indent}#{group.description}"
+        end
+        @current_groups = groups
+      end
+
+      def print_example(result, depth)
+        indent = "  " * depth
+        desc = result.example.description
+
+        if result.passed?
+          puts "#{indent}✅ #{desc}".green
+        elsif result.pending?
+          puts "#{indent}🔀 #{desc}".brown
+        elsif result.failed?
+          puts "#{indent}❌ #{desc}".red
+          puts "#{indent}   #{result.error.message}".red
+        end
+      end
+
+      def print_counts(results)
+        passed  = results.count { |r| r.passed? }
+        failed  = results.count { |r| r.failed? }
+        pending = results.count { |r| r.pending? }
+
+        parts = ["#{passed} passed".green]
+        parts << "#{failed} failed".red if failed > 0
+        parts << "#{pending} pending".brown if pending > 0
+        puts parts.join(", ")
+      end
+
+      def print_failures(results)
+        failed = results.select { |r| r.failed? }
+        return if failed.empty?
+
+        puts ""
+        puts "Failures:".red
+        failed.each_with_index do |r, i|
+          puts "  #{i + 1}) #{r.example.full_description}".red
+          puts "     #{r.error.message}".red
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

RSpec-style `--format documentation` reporter that displays the full spec tree with indented descriptions.

### Usage
```bash
./dragonruby . --eval app/tests.rb --no-tick --doc
```
Or programmatically:
```ruby
run_specs(reporter: DrSpec::Reporters::Doc.new)
```

### Output example
```
string_matchers
  ✅ start_with
  ✅ end_with
architecture
  example_group
    tree construction
      ✅ ExampleGroup has children and parent
      ✅ full_description concatenates ancestor descriptions
  scope_isolation
    each it block gets its own ExampleContext
      ✅ first test increments counter
      ✅ second test sees fresh counter

100 passed, 2 pending
```

### Key files
- `lib/dr_spec/reporters/doc.rb` — Doc reporter with group transition tracking
- `lib/dr_spec/dragon_specs.rb` — `select_reporter` + `run_specs(reporter:)` param

### What to verify
- Run with `--doc` flag, check indentation and group transitions
- Compare with dots output to ensure same test count

## Test plan
- [x] 100 tests passed (dots mode)
- [x] Doc mode displays correctly with indentation
- [x] Rubocop clean
- [x] Lefthook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)