### PR TITLE
Add Smaug package manager compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,28 @@ All new features and fixes target `dr_spec_2`. Once the community has validated 
 
 That's it! Now you can write specs for your app using `dr_spec`.
 
-### Using `smaug`
+### Using Smaug
 
-If you're using `smaug` to manage dependencies, you can install `dr_spec` by adding it to your `Smaug.toml`:
+[Smaug](https://smaug.dev/) is the DragonRuby package manager. To install dr_spec via Smaug, add it to your project's `Smaug.toml`:
 
 ```toml
+[dependencies]
 dr_spec = { repo = "https://github.com/levaleureux/dr_spec" }
 ```
 
-Then simply run `smaug install` and add `require "smaug/dr_spec/lib/dr_spec/dragon_specs`
-to your `app/main.rb` or `app/test.rb` file.
+Then run:
+
+```bash
+smaug install
+```
+
+In your `app/main.rb` or `app/test.rb`, require dr_spec from the Smaug install path:
+
+```ruby
+require "smaug/dr_spec/lib/dr_spec/dragon_specs.rb"
+```
+
+All internal requires use `require_relative`, so dr_spec works correctly from the `smaug/` directory without any path issues.
 
 ## Setup
 
@@ -57,7 +69,7 @@ your specs entrypoint file. This is normally `app/main.rb` or `app/test.rb`, but
 
 ```ruby
 # spec/main.rb
-require "lib/dr_spec/dragon_specs.rb" # or if you're using smaug: require 'smaug/dr_spec/lib/dr_spec/dragon_specs'
+require "lib/dr_spec/dragon_specs.rb" # or if you're using smaug: require "smaug/dr_spec/lib/dr_spec/dragon_specs.rb"
 
 spec "Setup specs" do
   specify "works" do

--- a/Smaug.toml
+++ b/Smaug.toml
@@ -1,22 +1,19 @@
 [package]
 name = "dr_spec"
+version = "2.0.0"
 authors = ["levaleureux"]
-version = "0.1.0"
+description = "RSpec-like test framework for DragonRuby"
 homepage = "https://github.com/levaleureux/dr_spec"
-keywords = ['dragonruby', 'rspec']
-
-# Optional:
-# documentation = "https://example.com"
 repository = "https://github.com/levaleureux/dr_spec"
+keywords = ['dragonruby', 'rspec', 'testing']
 
-# Which files do you want to be automatically required from your package.
+# Smaug auto-requires: the user requires dragon_specs.rb which pulls in everything
+# via require_relative (works from any install location).
 requires = []
 
 [package.installs]
-# Example
-#
-# <from> = <to>
-# "lib/library.rb" = "app/lib/library.rb"
+# No installs mapping needed — dr_spec uses require_relative internally,
+# so it works directly from the smaug/ directory.
 
 [dragonruby]
 version = "5.9"


### PR DESCRIPTION
## Summary

- Update `Smaug.toml` to v2.0.0 with description, keywords, and clarified comments
- Improve README Smaug installation section with step-by-step instructions
- Document that `require_relative` ensures dr_spec works from `smaug/` directory

Closes #78

## Details

The key finding: `dragon_specs.rb` on `develop` already uses `require_relative` for all internal requires (unlike the old `require "lib/dr_spec/..."` paths). This means dr_spec already works correctly when installed via Smaug -- no code changes needed, just config and docs updates.

### Files changed

| File | Change |
|------|--------|
| `Smaug.toml` | Version bump to 2.0.0, added description/keywords, clarified install comments |
| `README.md` | Expanded Smaug section with `[dependencies]` block, `smaug install` command, and note about require_relative |

## Test plan

- [ ] Verify `smaug install` fetches dr_spec into `smaug/dr_spec/`
- [ ] Verify `require "smaug/dr_spec/lib/dr_spec/dragon_specs.rb"` loads correctly
- [ ] Verify `smaug run --test spec/main.rb` runs tests successfully
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)