### PR TITLE
Add tag filtering for specs (#7)

### DIFF
--- a/app/tests.rb
+++ b/app/tests.rb
@@ -22,6 +22,7 @@ require "spec/coverage_start_spec.rb"
 require "spec/json_reporter_spec.rb"
 require "spec/html_reporter_spec.rb"
 require "spec/tick_based_spec.rb"
+require "spec/tags_spec.rb"
 require "spec/main_spec.rb"
 
 puts "Test where run"

--- a/lib/dr_spec/core/configuration.rb
+++ b/lib/dr_spec/core/configuration.rb
@@ -6,7 +6,7 @@ module DrSpec
       @instance ||= new
     end
 
-    def self.reset!
+    def self.reset
       @instance = nil
     end
 

--- a/lib/dr_spec/core/configuration.rb
+++ b/lib/dr_spec/core/configuration.rb
@@ -1,10 +1,36 @@
 module DrSpec
   class Configuration
-    attr_accessor :format_mode, :log_level
+    attr_accessor :format_mode, :log_level, :tag_filters
+
+    def self.instance
+      @instance ||= new
+    end
+
+    def self.reset!
+      @instance = nil
+    end
 
     def initialize
       @format_mode = :doc
       @log_level   = :on
+      @tag_filters = []
+    end
+
+    # Parse --tag from CLI arguments
+    # $gtk.cli_arguments returns a hash like { :"tag" => "fast" }
+    def apply_cli_arguments(cli_args)
+      return unless cli_args
+
+      if cli_args.keys.include?(:tag)
+        value = cli_args[:tag]
+        if value.is_a?(String) && value.length > 0
+          @tag_filters = value.split(",").map { |t| t.strip.to_sym }
+        end
+      end
+    end
+
+    def tag_filter_active?
+      @tag_filters.length > 0
     end
   end
 end

--- a/lib/dr_spec/core/dsl.rb
+++ b/lib/dr_spec/core/dsl.rb
@@ -13,10 +13,11 @@ def focus_spec(name, metadata = {}, &block)
   spec(name, metadata.merge(focus: true), &block)
 end
 
-def context(description, &block)
+def context(description, metadata = {}, &block)
   world  = DrSpec::World.instance
   parent = world.current_group
-  child  = DrSpec::ExampleGroup.new(description, parent: parent)
+  meta   = DrSpec::Metadata.new(metadata)
+  child  = DrSpec::ExampleGroup.new(description, parent: parent, metadata: meta)
   parent.add_child(child)
   world.push_group(child)
   block.call

--- a/lib/dr_spec/core/example_group.rb
+++ b/lib/dr_spec/core/example_group.rb
@@ -46,6 +46,20 @@ module DrSpec
       chain.map(&:description).join("_")
     end
 
+    # Check if this group or any ancestor has any of the given tags
+    def has_any_tag?(tag_list)
+      chain = ancestor_chain
+      chain.any? do |group|
+        tag_list.any? { |tag| group.metadata.has_tag?(tag) }
+      end
+    end
+
+    # Collect all tags from this group and its ancestors
+    def collected_tags
+      chain = ancestor_chain
+      chain.flat_map { |g| g.metadata.tags }
+    end
+
     # DFS iterator over all examples in this group and children
     def each_example(&block)
       @examples.each(&block)

--- a/lib/dr_spec/core/metadata.rb
+++ b/lib/dr_spec/core/metadata.rb
@@ -16,6 +16,10 @@ module DrSpec
       @data[:tags] || []
     end
 
+    def has_tag?(tag)
+      tags.include?(tag)
+    end
+
     def [](key)
       @data[key]
     end

--- a/lib/dr_spec/core/runner.rb
+++ b/lib/dr_spec/core/runner.rb
@@ -58,6 +58,8 @@ module DrSpec
 
     # Recursively collect examples from groups that match any of the given tags.
     # A group matches if it or any of its ancestors has a matching tag.
+    # Tag inheritance: when a parent group matches, ALL children are included
+    # regardless of their own tags.
     def collect_tagged_examples(group, tag_filters, examples)
       if group.has_any_tag?(tag_filters)
         # This group matches — include all its examples

--- a/lib/dr_spec/core/runner.rb
+++ b/lib/dr_spec/core/runner.rb
@@ -40,10 +40,38 @@ module DrSpec
       focused = groups.select { |g| g.metadata.focused? }
       target_groups = focused.any? ? focused : groups
 
-      target_groups.each do |group|
-        group.each_example { |ex| examples << ex }
+      config = DrSpec::Configuration.instance
+
+      if config.tag_filter_active?
+        # Tag filtering: collect examples only from groups matching tags
+        target_groups.each do |group|
+          collect_tagged_examples(group, config.tag_filters, examples)
+        end
+      else
+        target_groups.each do |group|
+          group.each_example { |ex| examples << ex }
+        end
       end
+
       examples
+    end
+
+    # Recursively collect examples from groups that match any of the given tags.
+    # A group matches if it or any of its ancestors has a matching tag.
+    def collect_tagged_examples(group, tag_filters, examples)
+      if group.has_any_tag?(tag_filters)
+        # This group matches — include all its examples
+        group.examples.each { |ex| examples << ex }
+        # And all children recursively (they inherit the tag match)
+        group.children.each do |child|
+          child.each_example { |ex| examples << ex }
+        end
+      else
+        # This group doesn't match, but a child might have its own tags
+        group.children.each do |child|
+          collect_tagged_examples(child, tag_filters, examples)
+        end
+      end
     end
   end
 end

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -4,6 +4,9 @@ def run_specs(reporter: nil)
   puts "================      running tests ========="
   puts "💨 running tests"
 
+  # Apply CLI arguments (e.g. --tag fast)
+  DrSpec::Configuration.instance.apply_cli_arguments($gtk.cli_arguments)
+
   reporter ||= select_reporter
   runner = DrSpec::Runner.new(reporter: reporter)
   runner.run

--- a/spec/tags_spec.rb
+++ b/spec/tags_spec.rb
@@ -86,7 +86,7 @@ spec "tags and filtering" do
   context "Runner tag filtering" do
     specify "without tag filter, all examples are collected" do
       # Reset configuration to ensure no filters
-      DrSpec::Configuration.reset!
+      DrSpec::Configuration.reset
 
       group1 = DrSpec::ExampleGroup.new("g1", metadata: DrSpec::Metadata.new(tags: [:fast]))
       ex1 = DrSpec::Example.new("ex1", group: group1, block: proc { })
@@ -99,26 +99,28 @@ spec "tags and filtering" do
       world = DrSpec::World.instance
       original_groups = world.example_groups.dup
 
-      # Temporarily add our test groups
-      world.example_groups.clear
-      world.example_groups << group1
-      world.example_groups << group2
+      begin
+        # Temporarily add our test groups
+        world.example_groups.clear
+        world.example_groups << group1
+        world.example_groups << group2
 
-      reporter = DrSpec::Reporters::Quiet.new
-      runner = DrSpec::Runner.new(reporter: reporter)
+        reporter = DrSpec::Reporters::Quiet.new
+        runner = DrSpec::Runner.new(reporter: reporter)
 
-      # Use send to access private method
-      examples = runner.send(:collect_examples)
-      expect(examples.length).to eq 2
-
-      # Restore original groups
-      world.example_groups.clear
-      original_groups.each { |g| world.example_groups << g }
-      DrSpec::Configuration.reset!
+        # Use send to access private method
+        examples = runner.send(:collect_examples)
+        expect(examples.length).to eq 2
+      ensure
+        # Restore original groups
+        world.example_groups.clear
+        original_groups.each { |g| world.example_groups << g }
+        DrSpec::Configuration.reset
+      end
     end
 
     specify "with tag filter, only matching groups run" do
-      DrSpec::Configuration.reset!
+      DrSpec::Configuration.reset
       config = DrSpec::Configuration.instance
       config.tag_filters = [:fast]
 
@@ -133,25 +135,27 @@ spec "tags and filtering" do
       world = DrSpec::World.instance
       original_groups = world.example_groups.dup
 
-      world.example_groups.clear
-      world.example_groups << group_fast
-      world.example_groups << group_slow
+      begin
+        world.example_groups.clear
+        world.example_groups << group_fast
+        world.example_groups << group_slow
 
-      reporter = DrSpec::Reporters::Quiet.new
-      runner = DrSpec::Runner.new(reporter: reporter)
+        reporter = DrSpec::Reporters::Quiet.new
+        runner = DrSpec::Runner.new(reporter: reporter)
 
-      examples = runner.send(:collect_examples)
-      expect(examples.length).to eq 1
-      expect(examples[0].description).to eq "fast_ex"
-
-      # Restore
-      world.example_groups.clear
-      original_groups.each { |g| world.example_groups << g }
-      DrSpec::Configuration.reset!
+        examples = runner.send(:collect_examples)
+        expect(examples.length).to eq 1
+        expect(examples[0].description).to eq "fast_ex"
+      ensure
+        # Restore
+        world.example_groups.clear
+        original_groups.each { |g| world.example_groups << g }
+        DrSpec::Configuration.reset
+      end
     end
 
     specify "tag filter works on nested contexts" do
-      DrSpec::Configuration.reset!
+      DrSpec::Configuration.reset
       config = DrSpec::Configuration.instance
       config.tag_filters = [:db]
 
@@ -169,20 +173,22 @@ spec "tags and filtering" do
       world = DrSpec::World.instance
       original_groups = world.example_groups.dup
 
-      world.example_groups.clear
-      world.example_groups << root
+      begin
+        world.example_groups.clear
+        world.example_groups << root
 
-      reporter = DrSpec::Reporters::Quiet.new
-      runner = DrSpec::Runner.new(reporter: reporter)
+        reporter = DrSpec::Reporters::Quiet.new
+        runner = DrSpec::Runner.new(reporter: reporter)
 
-      examples = runner.send(:collect_examples)
-      expect(examples.length).to eq 1
-      expect(examples[0].description).to eq "db_test"
-
-      # Restore
-      world.example_groups.clear
-      original_groups.each { |g| world.example_groups << g }
-      DrSpec::Configuration.reset!
+        examples = runner.send(:collect_examples)
+        expect(examples.length).to eq 1
+        expect(examples[0].description).to eq "db_test"
+      ensure
+        # Restore
+        world.example_groups.clear
+        original_groups.each { |g| world.example_groups << g }
+        DrSpec::Configuration.reset
+      end
     end
   end
 

--- a/spec/tags_spec.rb
+++ b/spec/tags_spec.rb
@@ -1,0 +1,199 @@
+# Tags and filtering (issue #7)
+#
+spec "tags and filtering" do
+
+  context "Metadata tags" do
+    specify "tags returns empty array by default" do
+      meta = DrSpec::Metadata.new
+      expect(meta.tags).to eq []
+    end
+
+    specify "tags returns the tags from the hash" do
+      meta = DrSpec::Metadata.new(tags: [:fast, :unit])
+      expect(meta.tags).to eq [:fast, :unit]
+    end
+
+    specify "has_tag? returns true when tag is present" do
+      meta = DrSpec::Metadata.new(tags: [:fast, :unit])
+      expect(meta.has_tag?(:fast)).to be_truthy
+    end
+
+    specify "has_tag? returns false when tag is absent" do
+      meta = DrSpec::Metadata.new(tags: [:fast])
+      expect(meta.has_tag?(:slow)).to be_falsy
+    end
+  end
+
+  context "ExampleGroup tag inheritance" do
+    specify "has_any_tag? finds tag on the group itself" do
+      meta  = DrSpec::Metadata.new(tags: [:fast])
+      group = DrSpec::ExampleGroup.new("tagged", metadata: meta)
+      expect(group.has_any_tag?([:fast])).to be_truthy
+    end
+
+    specify "has_any_tag? finds tag on an ancestor" do
+      parent_meta = DrSpec::Metadata.new(tags: [:integration])
+      parent = DrSpec::ExampleGroup.new("parent", metadata: parent_meta)
+      child  = DrSpec::ExampleGroup.new("child", parent: parent)
+      expect(child.has_any_tag?([:integration])).to be_truthy
+    end
+
+    specify "has_any_tag? returns false when no match" do
+      group = DrSpec::ExampleGroup.new("untagged")
+      expect(group.has_any_tag?([:fast])).to be_falsy
+    end
+
+    specify "collected_tags gathers tags from ancestors" do
+      parent_meta = DrSpec::Metadata.new(tags: [:slow])
+      child_meta  = DrSpec::Metadata.new(tags: [:db])
+      parent = DrSpec::ExampleGroup.new("parent", metadata: parent_meta)
+      child  = DrSpec::ExampleGroup.new("child", parent: parent, metadata: child_meta)
+      expect(child.collected_tags).to eq [:slow, :db]
+    end
+  end
+
+  context "Configuration tag filters" do
+    specify "tag_filters is empty by default" do
+      config = DrSpec::Configuration.new
+      expect(config.tag_filters).to eq []
+    end
+
+    specify "tag_filter_active? is false when no filters" do
+      config = DrSpec::Configuration.new
+      expect(config.tag_filter_active?).to be_falsy
+    end
+
+    specify "apply_cli_arguments sets tag filters from --tag" do
+      config = DrSpec::Configuration.new
+      config.apply_cli_arguments({ tag: "fast" })
+      expect(config.tag_filters).to eq [:fast]
+      expect(config.tag_filter_active?).to be_truthy
+    end
+
+    specify "apply_cli_arguments handles comma-separated tags" do
+      config = DrSpec::Configuration.new
+      config.apply_cli_arguments({ tag: "fast,unit" })
+      expect(config.tag_filters).to eq [:fast, :unit]
+    end
+
+    specify "apply_cli_arguments handles nil safely" do
+      config = DrSpec::Configuration.new
+      config.apply_cli_arguments(nil)
+      expect(config.tag_filters).to eq []
+    end
+  end
+
+  context "Runner tag filtering" do
+    specify "without tag filter, all examples are collected" do
+      # Reset configuration to ensure no filters
+      DrSpec::Configuration.reset!
+
+      group1 = DrSpec::ExampleGroup.new("g1", metadata: DrSpec::Metadata.new(tags: [:fast]))
+      ex1 = DrSpec::Example.new("ex1", group: group1, block: proc { })
+      group1.add_example(ex1)
+
+      group2 = DrSpec::ExampleGroup.new("g2")
+      ex2 = DrSpec::Example.new("ex2", group: group2, block: proc { })
+      group2.add_example(ex2)
+
+      world = DrSpec::World.instance
+      original_groups = world.example_groups.dup
+
+      # Temporarily add our test groups
+      world.example_groups.clear
+      world.example_groups << group1
+      world.example_groups << group2
+
+      reporter = DrSpec::Reporters::Quiet.new
+      runner = DrSpec::Runner.new(reporter: reporter)
+
+      # Use send to access private method
+      examples = runner.send(:collect_examples)
+      expect(examples.length).to eq 2
+
+      # Restore original groups
+      world.example_groups.clear
+      original_groups.each { |g| world.example_groups << g }
+      DrSpec::Configuration.reset!
+    end
+
+    specify "with tag filter, only matching groups run" do
+      DrSpec::Configuration.reset!
+      config = DrSpec::Configuration.instance
+      config.tag_filters = [:fast]
+
+      group_fast = DrSpec::ExampleGroup.new("fast_group", metadata: DrSpec::Metadata.new(tags: [:fast]))
+      ex_fast = DrSpec::Example.new("fast_ex", group: group_fast, block: proc { })
+      group_fast.add_example(ex_fast)
+
+      group_slow = DrSpec::ExampleGroup.new("slow_group", metadata: DrSpec::Metadata.new(tags: [:slow]))
+      ex_slow = DrSpec::Example.new("slow_ex", group: group_slow, block: proc { })
+      group_slow.add_example(ex_slow)
+
+      world = DrSpec::World.instance
+      original_groups = world.example_groups.dup
+
+      world.example_groups.clear
+      world.example_groups << group_fast
+      world.example_groups << group_slow
+
+      reporter = DrSpec::Reporters::Quiet.new
+      runner = DrSpec::Runner.new(reporter: reporter)
+
+      examples = runner.send(:collect_examples)
+      expect(examples.length).to eq 1
+      expect(examples[0].description).to eq "fast_ex"
+
+      # Restore
+      world.example_groups.clear
+      original_groups.each { |g| world.example_groups << g }
+      DrSpec::Configuration.reset!
+    end
+
+    specify "tag filter works on nested contexts" do
+      DrSpec::Configuration.reset!
+      config = DrSpec::Configuration.instance
+      config.tag_filters = [:db]
+
+      root = DrSpec::ExampleGroup.new("root")
+      child = DrSpec::ExampleGroup.new("db_context", parent: root, metadata: DrSpec::Metadata.new(tags: [:db]))
+      ex_db = DrSpec::Example.new("db_test", group: child, block: proc { })
+      child.add_example(ex_db)
+      root.add_child(child)
+
+      untagged_child = DrSpec::ExampleGroup.new("other", parent: root)
+      ex_other = DrSpec::Example.new("other_test", group: untagged_child, block: proc { })
+      untagged_child.add_example(ex_other)
+      root.add_child(untagged_child)
+
+      world = DrSpec::World.instance
+      original_groups = world.example_groups.dup
+
+      world.example_groups.clear
+      world.example_groups << root
+
+      reporter = DrSpec::Reporters::Quiet.new
+      runner = DrSpec::Runner.new(reporter: reporter)
+
+      examples = runner.send(:collect_examples)
+      expect(examples.length).to eq 1
+      expect(examples[0].description).to eq "db_test"
+
+      # Restore
+      world.example_groups.clear
+      original_groups.each { |g| world.example_groups << g }
+      DrSpec::Configuration.reset!
+    end
+  end
+
+  context "DSL passes tags through" do
+    specify "spec DSL creates group with tags in metadata" do
+      world = DrSpec::World.instance
+      # The :string_matchers spec in matchers_1_spec.rb has tags: [:players]
+      players_group = world.example_groups.find { |g|
+        g.metadata.has_tag?(:players)
+      }
+      expect(players_group).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement `--tag` CLI option to filter which specs run based on tags (closes #7)
- Tags can be applied to `spec` and `context` blocks via metadata: `spec "foo", tags: [:fast] do ... end`
- When `--tag fast` is passed, only specs/contexts with matching tags run; without it, all tests run as before
- Tags are inherited: a tagged parent group includes all its children automatically

## Changes

**Core files modified:**
- `lib/dr_spec/core/metadata.rb` — add `has_tag?` method
- `lib/dr_spec/core/configuration.rb` — singleton pattern, `tag_filters`, `apply_cli_arguments` for `--tag` parsing
- `lib/dr_spec/core/example_group.rb` — `has_any_tag?` (checks group + ancestors), `collected_tags`
- `lib/dr_spec/core/dsl.rb` — `context` now accepts optional metadata hash (tags support)
- `lib/dr_spec/core/runner.rb` — `collect_tagged_examples` filters by tag when active
- `lib/dr_spec/dragon_specs.rb` — apply CLI arguments before running

**New files:**
- `spec/tags_spec.rb` — 16 tests covering metadata, group inheritance, configuration, runner filtering, and DSL integration

## Usage

```bash
# Run only specs tagged :fast
dragonruby . --eval app/tests.rb --tag fast

# Run specs tagged :fast or :unit
dragonruby . --eval app/tests.rb --tag fast,unit

# No --tag flag: all tests run (backward compatible)
dragonruby . --eval app/tests.rb
```

## Test plan

- [x] All existing tests pass (verified via pre-commit hook: rubocop, reek, dr_spec)
- [x] New tag filtering tests pass
- [ ] Manual test with `--tag players` to verify only `:string_matchers` spec runs
- [ ] Verify backward compatibility: no `--tag` flag runs all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)