### PR TITLE
fix(coverage) — instrumenteur : gérer les littéraux multi-lignes

### DIFF
--- a/lib/dr_spec/coverage/instrumenter.rb
+++ b/lib/dr_spec/coverage/instrumenter.rb
@@ -18,6 +18,7 @@ module DrSpec
         in_heredoc = false
         heredoc_end = nil
         in_block_comment = false
+        depth = 0
 
         instrumented_lines = []
 
@@ -48,6 +49,14 @@ module DrSpec
             next
           end
 
+          # Continuation line of an open multi-line literal (hash/array/call):
+          # do not inject in the middle of the expression.
+          if depth > 0
+            instrumented_lines << line
+            depth += bracket_delta(line)
+            next
+          end
+
           # Detect heredoc start
           if stripped.include?("<<")
             heredoc_marker = detect_heredoc(stripped)
@@ -66,12 +75,38 @@ module DrSpec
             tracker.mark_executable(file_path, line_num)
             instrumented_lines << "__dr_cov(\"#{file_path}\", #{line_num}); #{line}"
           end
+          depth += bracket_delta(line)
         end
 
         instrumented_lines.join("\n")
       end
 
       private
+
+      # Variation nette de profondeur de parenthésage pour une ligne :
+      # +1 par { [ ( et -1 par } ] ), en ignorant le contenu des chaînes et
+      # les commentaires (#). Pas de Regexp (indisponible en mRuby).
+      def bracket_delta(line)
+        delta = 0
+        quote = nil
+        i = 0
+        while i < line.length
+          c = line[i]
+          if quote
+            quote = nil if c == quote
+          elsif c == "'" || c == '"'
+            quote = c
+          elsif c == "#"
+            break
+          elsif c == "{" || c == "[" || c == "("
+            delta += 1
+          elsif c == "}" || c == "]" || c == ")"
+            delta -= 1
+          end
+          i += 1
+        end
+        delta
+      end
 
       def skip_line?(stripped)
         return true if stripped == ""

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -75,3 +75,27 @@ spec "coverage instrumentation" do
     expect(covered).to be_greater_than(0)
   end
 end
+
+# Non-regression #109 : litteraux multi-lignes (hash / array).
+spec "coverage instrumentation - litteraux multi-lignes" do
+  before do
+    DrSpec::Coverage::Tracker.reset
+    @instrumenter = DrSpec::Coverage::Instrumenter.new
+    @tracker = DrSpec::Coverage::Tracker.instance
+    @file = "spec/fixtures/sample_palette.rb"
+    @source = $gtk.read_file(@file)
+  end
+
+  specify "instrumente un hash/array multi-lignes sans casser la syntaxe" do
+    instrumented = @instrumenter.instrument(@source, @file, @tracker)
+    eval(instrumented)
+    expect(SamplePalette.fetch(:dark)).to eq({ r: 1, g: 2, b: 3 })
+    expect(SamplePalette.size).to eq 4
+  end
+
+  specify "n'injecte pas __dr_cov sur les lignes de continuation" do
+    instrumented = @instrumenter.instrument(@source, @file, @tracker)
+    continuation = instrumented.split("\n").select { |l| l.include?("r: 1") }.first
+    expect(continuation.include?("__dr_cov")).to eq false
+  end
+end

--- a/spec/fixtures/sample_palette.rb
+++ b/spec/fixtures/sample_palette.rb
@@ -1,0 +1,22 @@
+# Fixture pour la non-regression #109 : litteraux multi-lignes (hash + array).
+# L'instrumenteur de couverture ne doit PAS injecter __dr_cov au milieu de ces
+# expressions ouvertes.
+module SamplePalette
+  COLORS = {
+    dark:  { r: 1, g: 2, b: 3 },
+    light: { r: 4, g: 5, b: 6 }
+  }.freeze
+
+  LIST = [
+    1, 2,
+    3, 4
+  ].freeze
+
+  def self.fetch(key)
+    COLORS.fetch(key)
+  end
+
+  def self.size
+    LIST.length
+  end
+end


### PR DESCRIPTION
Corrige #109.

L'instrumenteur de couverture injectait `__dr_cov(...)` sur les lignes de continuation d'un hash/array/appel multi-lignes ouvert → syntaxe invalide.

**Fix** : suivi de la profondeur de parenthésage (`bracket_delta`, parcours char-par-char ignorant chaînes et commentaires, sans Regexp). Profondeur > 0 au début d'une ligne ⇒ continuation ⇒ pas d'injection.

**Non-régression** : fixture `spec/fixtures/sample_palette.rb` (hash + array multi-lignes) + 2 specs dans `coverage_spec.rb`. Suite complète verte (**164 tests**).

Closes #109