### PR TITLE
fix(coverage) — ne pas instrumenter les end terminateurs (end.freeze)

### DIFF
--- a/lib/dr_spec/coverage/instrumenter.rb
+++ b/lib/dr_spec/coverage/instrumenter.rb
@@ -112,8 +112,27 @@ module DrSpec
         return true if stripped == ""
         return true if stripped.start_with?("#")
         return true if SKIP_BARE.include?(stripped)
+        return true if end_terminator?(stripped)
 
         SKIP_PREFIXES.any? { |prefix| stripped.start_with?(prefix) }
+      end
+
+      # Vrai pour un `end` terminateur de bloc, meme suivi d'un appel ou d'un
+      # operateur (end, end.freeze, end), end,). Instrumenter ces lignes
+      # placerait __dr_cov AVANT le end -> il deviendrait la derniere
+      # expression du bloc et detournerait sa valeur de retour. On exclut les
+      # identifiants commencant par "end" (ending, endpoint).
+      def end_terminator?(stripped)
+        return false unless stripped.start_with?("end")
+
+        after = stripped[3]
+        after.nil? || !word_char?(after)
+      end
+
+      def word_char?(char)
+        (char >= "a" && char <= "z") ||
+          (char >= "A" && char <= "Z") ||
+          (char >= "0" && char <= "9") || char == "_"
       end
 
       def detect_heredoc(line)

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -93,6 +93,12 @@ spec "coverage instrumentation - litteraux multi-lignes" do
     expect(SamplePalette.size).to eq 4
   end
 
+  specify "ne detourne pas la valeur d'un bloc do...end.freeze (#111)" do
+    instrumented = @instrumenter.instrument(@source, @file, @tracker)
+    eval(instrumented)
+    expect(SamplePalette.squares).to eq [0, 1, 4, 9]
+  end
+
   specify "n'injecte pas __dr_cov sur les lignes de continuation" do
     instrumented = @instrumenter.instrument(@source, @file, @tracker)
     continuation = instrumented.split("\n").select { |l| l.include?("r: 1") }.first

--- a/spec/fixtures/sample_palette.rb
+++ b/spec/fixtures/sample_palette.rb
@@ -12,8 +12,18 @@ module SamplePalette
     3, 4
   ].freeze
 
+  # Bloc do...end.freeze : la valeur de retour ne doit PAS etre detournee
+  # par l'instrumentation (cf. #111).
+  SQUARES = Array.new(4) do |i|
+    i * i
+  end.freeze
+
   def self.fetch(key)
     COLORS.fetch(key)
+  end
+
+  def self.squares
+    SQUARES
   end
 
   def self.size


### PR DESCRIPTION
Corrige #111 (suite de #109).

Une ligne `end.freeze` fermant un bloc `do…end` était instrumentée → `__dr_cov(...)` devenait la dernière expression du bloc et détournait sa valeur de retour (`Array.new(n) do … end.freeze` → `[1,1,1,…]`).

**Fix** : `end_terminator?` reconnaît `end` suivi de fin de ligne ou d'un caractère non alphanumérique (sans attraper `ending`/`endpoint`).

**Non-régression** : fixture enrichie d'un `Array.new(4) do |i| i*i end.freeze` + assertion `[0,1,4,9]`. Suite verte (**165 tests**).

Closes #111