### PR TITLE
fix(coverage) — instrumenteur : continuations par opérateur en fin de ligne (#113)

### DIFF
--- a/lib/dr_spec/coverage/instrumenter.rb
+++ b/lib/dr_spec/coverage/instrumenter.rb
@@ -10,6 +10,14 @@ module DrSpec
         "def ", "rescue ", "ensure ", "when ", "elsif "
       ].freeze
 
+      # Operateurs binaires qui, en FIN de ligne, prolongent l'expression sur la
+      # ligne suivante. On exclut sciemment "|" et "&" isoles ("do |x|" finit par
+      # "|", "foo(&" ouvre une parenthese -> deja gere par la profondeur).
+      CONTINUATION_OPERATORS = [
+        "&&", "||", ",", ".", "&.", "+", "-", "*", "/", "%",
+        "==", "!=", "<=", ">=", "<", ">", "="
+      ].freeze
+
       def instrument(source, file_path, tracker)
         lines = source.split("\n")
         source_lines = lines.map { |l| "#{l}\n" }
@@ -19,6 +27,7 @@ module DrSpec
         heredoc_end = nil
         in_block_comment = false
         depth = 0
+        prev_continues = false
 
         instrumented_lines = []
 
@@ -30,15 +39,18 @@ module DrSpec
           if stripped == "=begin"
             in_block_comment = true
             instrumented_lines << line
+            prev_continues = false
             next
           end
           if stripped == "=end"
             in_block_comment = false
             instrumented_lines << line
+            prev_continues = false
             next
           end
           if in_block_comment
             instrumented_lines << line
+            prev_continues = false
             next
           end
 
@@ -46,14 +58,17 @@ module DrSpec
           if in_heredoc
             in_heredoc = false if stripped == heredoc_end
             instrumented_lines << line
+            prev_continues = false
             next
           end
 
-          # Continuation line of an open multi-line literal (hash/array/call):
-          # do not inject in the middle of the expression.
-          if depth > 0
+          # Continuation : litteral multi-lignes ouvert (crochet) OU ligne
+          # precedente terminee par un operateur de continuation (&&, +, ...).
+          # Ne pas injecter __dr_cov au milieu de l'expression.
+          if depth > 0 || prev_continues
             instrumented_lines << line
             depth += bracket_delta(line)
+            prev_continues = depth.zero? && continuation?(line)
             next
           end
 
@@ -65,6 +80,7 @@ module DrSpec
               heredoc_end = heredoc_marker
               tracker.mark_executable(file_path, line_num)
               instrumented_lines << "__dr_cov(\"#{file_path}\", #{line_num}); #{line}"
+              prev_continues = false
               next
             end
           end
@@ -76,6 +92,7 @@ module DrSpec
             instrumented_lines << "__dr_cov(\"#{file_path}\", #{line_num}); #{line}"
           end
           depth += bracket_delta(line)
+          prev_continues = depth.zero? && continuation?(line)
         end
 
         instrumented_lines.join("\n")
@@ -106,6 +123,36 @@ module DrSpec
           i += 1
         end
         delta
+      end
+
+      # Vrai si la portion de CODE de la ligne (hors commentaire de fin) se
+      # termine par un operateur de continuation -> la ligne suivante prolonge
+      # l'expression et ne doit pas etre instrumentee.
+      def continuation?(line)
+        code = code_part(line).strip
+        return false if code == ""
+        return true if code.end_with?("\\")
+
+        CONTINUATION_OPERATORS.any? { |op| code.end_with?(op) }
+      end
+
+      # Portion de code de la ligne : retire un commentaire de fin (# hors
+      # chaine), avec le meme scan que bracket_delta (pas de Regexp en mRuby).
+      def code_part(line)
+        quote = nil
+        i = 0
+        while i < line.length
+          c = line[i]
+          if quote
+            quote = nil if c == quote
+          elsif c == "'" || c == '"'
+            quote = c
+          elsif c == "#"
+            return line[0...i]
+          end
+          i += 1
+        end
+        line
       end
 
       def skip_line?(stripped)

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -105,3 +105,29 @@ spec "coverage instrumentation - litteraux multi-lignes" do
     expect(continuation.include?("__dr_cov")).to eq false
   end
 end
+
+# Non-regression #113 : continuation d'expression par operateur (&&) en fin de
+# ligne. L'instrumenteur ne doit pas couper l'expression ni detourner sa valeur.
+spec "coverage instrumentation - continuations par operateur (#113)" do
+  before do
+    DrSpec::Coverage::Tracker.reset
+    @instrumenter = DrSpec::Coverage::Instrumenter.new
+    @tracker = DrSpec::Coverage::Tracker.instance
+    @file = "spec/fixtures/sample_palette.rb"
+    @source = $gtk.read_file(@file)
+  end
+
+  specify "ne detourne pas un predicat coupe par && en fin de ligne" do
+    instrumented = @instrumenter.instrument(@source, @file, @tracker)
+    eval(instrumented)
+    # x hors bornes -> doit etre false (et non le seul test sur y, qui serait vrai).
+    expect(SamplePalette.inside?(-1, 5, 10, 10)).to eq false
+    expect(SamplePalette.inside?(5, 5, 10, 10)).to eq true
+  end
+
+  specify "n'injecte pas __dr_cov sur la ligne de continuation (&&)" do
+    instrumented = @instrumenter.instrument(@source, @file, @tracker)
+    line = instrumented.split("\n").select { |l| l.include?("y >= 0 && y <= h") }.first
+    expect(line.include?("__dr_cov")).to eq false
+  end
+end

--- a/spec/fixtures/sample_palette.rb
+++ b/spec/fixtures/sample_palette.rb
@@ -29,4 +29,12 @@ module SamplePalette
   def self.size
     LIST.length
   end
+
+  # Predicat coupe par un operateur de continuation (&&) en fin de ligne (#113).
+  # L'instrumenteur ne doit PAS injecter __dr_cov sur la 2e ligne : sinon le &&
+  # rattacherait le marqueur et la methode ne renverrait que le test sur y.
+  def self.inside?(x, y, w, h)
+    x >= 0 && x <= w &&
+      y >= 0 && y <= h
+  end
 end


### PR DESCRIPTION
Corrige #113.

## Problème

L'instrumenteur de couverture suivait la profondeur de crochets `{ [ (` (#109) mais pas les **continuations par opérateur** en fin de ligne (`&&`, `||`, `+`, `.`, `,`…). Il injectait alors `__dr_cov(...)` en tête de la ligne de continuation, **coupant l'expression** et **détournant sa valeur de retour** — 3ᵉ bug du même genre après #109 (littéraux multi-lignes) et #111 (`end.<methode>`).

Symptôme déroutant : specs **vertes hors couverture**, **rouges sous couverture**. Un prédicat booléen multi-lignes (`a && b &&` / `c && d`) ne renvoyait plus que sa dernière sous-expression.

## Correctif

Même remède que #109 : un drapeau `prev_continues`, géré exactement comme `depth`, fait émettre la ligne de continuation **sans** `__dr_cov`.

- `continuation?(line)` : la portion de **code** (hors commentaire de fin) se termine-t-elle par un opérateur de continuation ?
- `code_part(line)` : retire un `#` commentaire hors chaîne (même scan que `bracket_delta`, sans Regexp — interdit en mRuby).
- `|` et `&` **isolés** exclus de la liste (`do |x|` finit par `|`, `foo(&` ouvre une parenthèse → déjà gérés par la profondeur).

## Risque de régression faible

Du code réel ne se termine quasiment jamais par un opérateur binaire **nu** sauf en continuation ; un opérateur oublié retombe simplement sur l'ancien comportement (liste extensible).

## Non-régression

- Fixture `SamplePalette.inside?` : prédicat coupé par `&&` en fin de ligne.
- 2 specs : la valeur de retour est préservée (`inside?(-1, 5, 10, 10) == false`) et la ligne de continuation ne reçoit pas de `__dr_cov`.
- **164 tests verts**, RuboCop propre.

## Propagation

Une fois mergé ici (source de vérité), re-vendoriser `lib/dr_spec/` dans les projets qui embarquent dr_spec (à commencer par `sonic_bonus_pur_claude`, où le contournement « prédicat sur une seule ligne » pourra être retiré).

🤖 Generated with [Claude Code](https://claude.com/claude-code)