### PR TITLE
feat(matchers): be_between(min, max) — bornes incluses (#108)

### DIFF
--- a/lib/dr_spec/matchers/numeric_comparison_matchers.rb
+++ b/lib/dr_spec/matchers/numeric_comparison_matchers.rb
@@ -52,3 +52,17 @@ end
 def be_less_than_or_equal_to expected, fail_with: ""
   LessThanOrEqualToMatcher.new expected, fail_with
 end
+
+# Bornes INCLUSES : passe si min <= actual <= max. @expected = [min, max].
+class BetweenMatcher < CoreMatcher
+  def positive_match? actual
+    [
+      actual >= @expected[0] && actual <= @expected[1],
+      "#{actual} is not between #{@expected[0]} and #{@expected[1]}. #{@fail_with}"
+    ]
+  end
+end
+
+def be_between min, max, fail_with: ""
+  BetweenMatcher.new([min, max], fail_with)
+end

--- a/spec/matchers_2_spec.rb
+++ b/spec/matchers_2_spec.rb
@@ -72,6 +72,13 @@ spec "Numeric Comparison matchers" do
     expect(5).to be_less_than_or_equal_to 5
     expect(5).not_to be_less_than_or_equal_to 4
   end
+  specify "be_between (bornes incluses)" do
+    expect(0).to be_between(0, 255)
+    expect(128).to be_between(0, 255)
+    expect(255).to be_between(0, 255)
+    expect(-1).not_to be_between(0, 255)
+    expect(256).not_to be_between(0, 255)
+  end
 end
 
 # Boolean matchers


### PR DESCRIPTION
## Quoi

Ajoute le matcher `be_between(min, max)` (bornes **incluses**), utilisé dans la doc et les specs de `sonic_bonus` / `dr_mod` mais jusqu'ici absent de dr_spec.

```ruby
expect(value).to be_between(0, 255)      # passe si 0 <= value <= 255
expect(value).not_to be_between(0, 255)
```

## Comment

`BetweenMatcher < CoreMatcher` stocke `@expected = [min, max]` et compare `actual >= min && actual <= max`. Message d'échec explicite (`"X is not between MIN and MAX"`). Même forme que les autres matchers numériques (`be_greater_than`, `be_less_than`…).

## Vérifs

- Spec : `expect(0/128/255).to be_between(0, 255)`, `expect(-1/256).not_to …` — verte.
- Suite : **168 verte, 0 échec**. `bin/rubocop_quiet` : 0 offense.

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)