### PR TITLE
feat: be_a/be_an aliases (#49) + require_specs auto-load (#50) — port v2 de @iMacTia

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ spec "Setup specs" do
 end
 ```
 
+## Organising specs
+
+Require each spec file in your entrypoint (after requiring dr_spec), then call
+`run_specs`. On **macOS/Linux** you can instead auto-load every
+`spec/**/*_spec.rb` recursively with the opt-in helper `require_specs`:
+
+```ruby
+require "lib/dr_spec/dragon_specs.rb"
+require_specs            # loads all spec/**/*_spec.rb (macOS/Linux)
+run_specs
+```
+
+> **Coverage note:** keep manual `require`s if you use code coverage — it needs
+> your app files loaded (and instrumented) **before** the specs. `require_specs`
+> is therefore opt-in, not automatic.
+
+_Auto-load idea contributed by [@iMacTia](https://github.com/iMacTia) (#50)._
+
 ## Running specs
 
 ### With manual install
@@ -306,10 +324,12 @@ expect(nil).to be_nil
 |---------|-------------|
 | `be_instance_of(klass)` | Verifies exact class match |
 | `be_kind_of(klass)` | Verifies class or ancestor match |
+| `be_a(klass)` / `be_an(klass)` | Aliases of `be_kind_of` |
 
 ```ruby
 expect("hello").to be_instance_of(String)
 expect(1).to be_kind_of(Numeric)
+expect([1, 2]).to be_an(Array)
 ```
 
 ### Collection

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -1,5 +1,21 @@
 $gtk.log_level = :on
 
+# Charge tous les specs (spec/**/*_spec.rb) recursivement, sur macOS/Linux.
+# OPT-IN : a appeler explicitement. On NE l'appelle pas automatiquement car
+# l'ordre de couverture exige de charger le code applicatif AVANT les specs.
+# Cf. #50, contribution d'iMacTia (porte sur la v2 en helper opt-in).
+def require_specs(current_dir = "spec")
+  $gtk.exec("ls #{current_dir}").to_s.split("\n").each do |entry|
+    if entry.end_with?("_spec.rb")
+      require "#{current_dir}/#{entry}"
+    elsif !entry.include?(".")
+      require_specs("#{current_dir}/#{entry}")
+    end
+  end
+rescue StandardError
+  puts "require_specs: auto-load indisponible (macOS/Linux uniquement)."
+end
+
 def run_specs(reporter: nil)
   puts "================      running tests ========="
   puts "💨 running tests"

--- a/lib/dr_spec/matchers/type_matchers.rb
+++ b/lib/dr_spec/matchers/type_matchers.rb
@@ -32,3 +32,7 @@ end
 def be_kind_of(expected, fail_with: "")
   BeKindOfMatcher.new(expected, fail_with)
 end
+
+# be_a / be_an : aliases de be_kind_of (cf. #49, contribution d'iMacTia).
+alias be_a be_kind_of
+alias be_an be_kind_of

--- a/spec/type_matchers_spec.rb
+++ b/spec/type_matchers_spec.rb
@@ -34,4 +34,19 @@ spec "type matchers" do
       expect("hello").not_to be_kind_of(Numeric)
     end
   end
+
+  # Aliases be_a / be_an de be_kind_of (#49, contribution d'iMacTia).
+  context "be_a / be_an (aliases de be_kind_of)" do
+    specify "be_a passe pour la classe parente" do
+      expect(42).to be_a(Numeric)
+    end
+
+    specify "be_an passe pour la classe exacte" do
+      expect([1, 2]).to be_an(Array)
+    end
+
+    specify "be_a échoue pour une classe sans lien" do
+      expect("hello").not_to be_a(Numeric)
+    end
+  end
 end


### PR DESCRIPTION
Porte sur la v2 deux contributions de **@iMacTia** restées sur la codebase 2023 (elles ne s'appliquaient plus telles quelles après la réécriture v2), en **créditant l'auteur** :

- **#49** — `be_a` / `be_an` comme aliases de `be_kind_of` (+ specs, doc README).
- **#50** — helper `require_specs` qui auto-charge `spec/**/*_spec.rb` récursivement (macOS/Linux). **Adapté en opt-in** (non automatique) pour préserver l'ordre de couverture v2.

Les PR d'origine #49 et #50 seront fermées avec remerciements (renvoi vers celle-ci).

Suite **182 verte**, rubocop 0.

Co-authored-by: @iMacTia

🤖 Generated with [Claude Code](https://claude.com/claude-code)